### PR TITLE
Create .NET Aspire AppHost and ServiceDefaults

### DIFF
--- a/.ai-team/agents/badger/history.md
+++ b/.ai-team/agents/badger/history.md
@@ -40,3 +40,6 @@
 - `ClientWPF/ENGINE.md` — Teleportation sequence diagram (`sequenceDiagram`)
 
 **Decision written:** `.ai-team/decisions/inbox/badger-diagram-standards.md`
+
+📌 Team update (2026-02-11): VB.NET respectful framing — never refer to VB.NET negatively, just "we're C# now" — decided by bradygaster
+📌 Team update (2026-02-11): Orleans + SignalR hybrid recommended — 4 grain types, Sprint 7 heavier, Sprint 11 lighter — decided by Heisenberg

--- a/.ai-team/agents/beth/history.md
+++ b/.ai-team/agents/beth/history.md
@@ -16,6 +16,12 @@ The blog is a first-class deliverable. Brady's directive: "We want to hand Hanse
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
 📌 Team update (2026-02-11): Beth's voice is fearless, developer-first, community-driven — decided by bradygaster
+
+📌 Team update (2026-02-11): Diagram standards — Mermaid only, no ASCII art. All diagrams must use Mermaid — decided by Badger, bradygaster
+📌 Team update (2026-02-11): VB.NET respectful framing — never refer to VB.NET negatively, just "we're C# now" — decided by bradygaster
+📌 Team update (2026-02-11): Orleans + SignalR hybrid recommended — 4 grain types for networking layer — decided by Heisenberg
+📌 Team update (2026-02-11): CI pipeline created (.github/workflows/build.yml) targeting src/Terrarium.sln — decided by Hank
+📌 Team update (2026-02-11): CSS token naming: --glass-{category}-{element}-{modifier}, BEM for components — decided by Jesse
 📌 Team update (2025-07-15): CSS tokens use `--glass-{category}-{element}-{modifier}` naming; BEM classes; `glass-theme.css` is single source of truth — decided by Jesse
 
 📌 Sprint 0 blog (2026-02-11): Wrote `docs/blog/journal/00-sprint-0-complete.md` covering the full foundation wave — 5 agents, 5 PRs, Mike's 91-file OrganismBase port, Jesse's Glass CSS tokens, Heisenberg's solution structure, Saul's Aspire AppHost, Hank's CI pipeline. Updated `docs/blog/announcement.md` with real Sprint 0 details in "The Challenge" and "The AI Story" sections.

--- a/.ai-team/agents/gus/history.md
+++ b/.ai-team/agents/gus/history.md
@@ -49,5 +49,11 @@
 📌 Team update (2026-02-10): Build must be green before new tests — decided by Hank
 📌 Team update (2026-02-10): .NET 10 modernization sprint plan created — 14 sprints, WPF on .NET 10, Silk.NET OpenGL, gRPC P2P, Dapper+stored procs, process isolation, xUnit, System.Text.Json — decided by Heisenberg
 📌 Team update (2026-02-11): Beth's voice is fearless, developer-first, community-driven — decided by bradygaster
+
+📌 Team update (2026-02-11): Diagram standards — Mermaid only, no ASCII art. All diagrams must use Mermaid — decided by Badger, bradygaster
+📌 Team update (2026-02-11): VB.NET respectful framing — never refer to VB.NET negatively, just "we're C# now" — decided by bradygaster
+📌 Team update (2026-02-11): Orleans + SignalR hybrid — SpeciesRegistryGrain and PopulationGrain implementation assigned to Gus in Sprint 7 — decided by Heisenberg
+📌 Team update (2026-02-11): CI pipeline created (.github/workflows/build.yml) targeting src/Terrarium.sln — decided by Hank
+📌 Team update (2026-02-11): CSS token naming: --glass-{category}-{element}-{modifier}, BEM for components — decided by Jesse
 📌 Team update (2025-07-16): Solution uses classic .sln format (not .slnx); CS1591 suppressed during initial port — decided by Heisenberg
 📌 Team update (2025-07-15): CSS tokens use `--glass-{category}-{element}-{modifier}` naming; BEM classes; `glass-theme.css` is single source of truth — decided by Jesse

--- a/.ai-team/agents/hank/history.md
+++ b/.ai-team/agents/hank/history.md
@@ -44,6 +44,12 @@
 📌 Team update (2026-02-10): .NET 10 modernization sprint plan created — 14 sprints, WPF on .NET 10, Silk.NET OpenGL, gRPC P2P, Dapper+stored procs, process isolation, xUnit, System.Text.Json — decided by Heisenberg
 📌 Team update (2026-02-11): Beth's voice is fearless, developer-first, community-driven — decided by bradygaster
 
+📌 Team update (2026-02-11): Diagram standards — Mermaid only, no ASCII art. All diagrams must use Mermaid — decided by Badger, bradygaster
+📌 Team update (2026-02-11): VB.NET respectful framing — never refer to VB.NET negatively, just "we're C# now" — decided by bradygaster
+📌 Team update (2026-02-11): Orleans + SignalR hybrid — TestCluster-based grain tests assigned to Hank in Sprint 7 — decided by Heisenberg
+📌 Team update (2026-02-11): Solution uses classic .sln (not .slnx), CS1591 suppressed during port — decided by Heisenberg
+📌 Team update (2026-02-11): CSS token naming: --glass-{category}-{element}-{modifier}, BEM for components — decided by Jesse
+
 ### 2025-07-15 — CI Pipeline Created (Issue #5)
 
 **What was done:**

--- a/.ai-team/agents/heisenberg/history.md
+++ b/.ai-team/agents/heisenberg/history.md
@@ -82,3 +82,9 @@
 - **Written to:** `.ai-team/decisions/inbox/heisenberg-orleans-evaluation.md`
 
 📌 Team update (2025-07-16): Orleans + SignalR hybrid recommended — Orleans for stateful domain (ecosystems, peers, species), SignalR as thin browser push channel — decided by Heisenberg
+
+📌 Team update (2026-02-11): Diagram standards — Mermaid only, no ASCII art. All diagrams must use Mermaid — decided by Badger, bradygaster
+📌 Team update (2026-02-11): VB.NET respectful framing — never refer to VB.NET negatively, just "we're C# now" — decided by bradygaster
+📌 Team update (2026-02-11): CI pipeline created (.github/workflows/build.yml) targeting src/Terrarium.sln — decided by Hank
+📌 Team update (2026-02-11): Solution uses classic .sln (not .slnx), CS1591 suppressed during port — decided by Heisenberg
+📌 Team update (2026-02-11): CSS token naming: --glass-{category}-{element}-{modifier}, BEM for components — decided by Jesse

--- a/.ai-team/agents/jesse/history.md
+++ b/.ai-team/agents/jesse/history.md
@@ -34,5 +34,10 @@
 📌 Team update (2026-02-10): Build must be green before new tests — decided by Hank
 📌 Team update (2026-02-10): .NET 10 modernization sprint plan created — 14 sprints, WPF on .NET 10, Silk.NET OpenGL, gRPC P2P, Dapper+stored procs, process isolation, xUnit, System.Text.Json — decided by Heisenberg
 📌 Team update (2026-02-11): Beth's voice is fearless, developer-first, community-driven — decided by bradygaster
+
+📌 Team update (2026-02-11): Diagram standards — Mermaid only, no ASCII art. All diagrams must use Mermaid — decided by Badger, bradygaster
+📌 Team update (2026-02-11): VB.NET respectful framing — never refer to VB.NET negatively, just "we're C# now" — decided by bradygaster
+📌 Team update (2026-02-11): Orleans + SignalR hybrid recommended — 4 grain types for networking layer — decided by Heisenberg
+📌 Team update (2026-02-11): CI pipeline created (.github/workflows/build.yml) targeting src/Terrarium.sln — decided by Hank
 📌 Team update (2025-07-16): Solution uses classic .sln format (not .slnx); CS1591 suppressed during initial port — decided by Heisenberg
 📌 Team update (2026-02-10): Keep ArrayList on Scan() until Game project ported — decided by Mike

--- a/.ai-team/agents/mike/history.md
+++ b/.ai-team/agents/mike/history.md
@@ -50,5 +50,11 @@
 📌 Team update (2026-02-10): Build must be green before new tests — decided by Hank
 📌 Team update (2026-02-10): .NET 10 modernization sprint plan created — 14 sprints, WPF on .NET 10, Silk.NET OpenGL, gRPC P2P, Dapper+stored procs, process isolation, xUnit, System.Text.Json — decided by Heisenberg
 📌 Team update (2026-02-11): Beth's voice is fearless, developer-first, community-driven — decided by bradygaster
+
+📌 Team update (2026-02-11): Diagram standards — Mermaid only, no ASCII art. All diagrams must use Mermaid — decided by Badger, bradygaster
+📌 Team update (2026-02-11): VB.NET respectful framing — never refer to VB.NET negatively, just "we're C# now" — decided by bradygaster
+📌 Team update (2026-02-11): Orleans + SignalR hybrid — EcosystemGrain tick loop, PeerGrain leases, SpeciesRegistryGrain CRUD, PopulationGrain write-behind. Sprint 7 grain implementation — decided by Heisenberg
+📌 Team update (2026-02-11): CI pipeline created (.github/workflows/build.yml) targeting src/Terrarium.sln — decided by Hank
+📌 Team update (2026-02-11): CSS token naming: --glass-{category}-{element}-{modifier}, BEM for components — decided by Jesse
 📌 Team update (2025-07-16): Solution uses classic .sln format (not .slnx); CS1591 suppressed during initial port — decided by Heisenberg
 📌 Team update (2025-07-15): CSS tokens use `--glass-{category}-{element}-{modifier}` naming; BEM classes; `glass-theme.css` is single source of truth — decided by Jesse

--- a/.ai-team/agents/saul/history.md
+++ b/.ai-team/agents/saul/history.md
@@ -10,6 +10,12 @@
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
 📌 Team update (2026-02-11): Beth's voice is fearless, developer-first, community-driven — decided by bradygaster
+
+📌 Team update (2026-02-11): Diagram standards — Mermaid only, no ASCII art. All diagrams must use Mermaid — decided by Badger, bradygaster
+📌 Team update (2026-02-11): VB.NET respectful framing — never refer to VB.NET negatively, just "we're C# now" — decided by bradygaster
+📌 Team update (2026-02-11): Orleans + SignalR hybrid — Aspire integration (AddOrleans) and SignalR.Orleans backplane assigned to Saul in Sprint 7 — decided by Heisenberg
+📌 Team update (2026-02-11): CI pipeline created (.github/workflows/build.yml) targeting src/Terrarium.sln — decided by Hank
+📌 Team update (2026-02-11): CSS token naming: --glass-{category}-{element}-{modifier}, BEM for components — decided by Jesse
 📌 Team update (2025-07-16): Solution uses classic .sln format (not .slnx); CS1591 suppressed during initial port — decided by Heisenberg
 
 📌 Aspire AppHost created (2026-02-11): Created Terrarium.AppHost (Aspire 13.1.0 with AppHost.Sdk) and Terrarium.ServiceDefaults (OpenTelemetry 1.15.0, ServiceDiscovery 10.3.0, Http.Resilience 10.3.0). Both build clean on .NET 10.0.103. Aspire no longer requires a workload in .NET 10 — it's purely NuGet-based. ServiceDefaults project reference needs IsAspireProjectResource="false" in the AppHost csproj to avoid ASPIRE004 warning. Server and Web project references are commented out until those projects are created.

--- a/.ai-team/agents/saul/history.md
+++ b/.ai-team/agents/saul/history.md
@@ -11,3 +11,5 @@
 
 📌 Team update (2026-02-11): Beth's voice is fearless, developer-first, community-driven — decided by bradygaster
 📌 Team update (2025-07-16): Solution uses classic .sln format (not .slnx); CS1591 suppressed during initial port — decided by Heisenberg
+
+📌 Aspire AppHost created (2026-02-11): Created Terrarium.AppHost (Aspire 13.1.0 with AppHost.Sdk) and Terrarium.ServiceDefaults (OpenTelemetry 1.15.0, ServiceDiscovery 10.3.0, Http.Resilience 10.3.0). Both build clean on .NET 10.0.103. Aspire no longer requires a workload in .NET 10 — it's purely NuGet-based. ServiceDefaults project reference needs IsAspireProjectResource="false" in the AppHost csproj to avoid ASPIRE004 warning. Server and Web project references are commented out until those projects are created.

--- a/.ai-team/agents/skyler/history.md
+++ b/.ai-team/agents/skyler/history.md
@@ -10,3 +10,9 @@
 <!-- Append new learnings below. Each entry is something lasting about the project. -->
 
 📌 Team update (2026-02-11): Beth's voice is fearless, developer-first, community-driven — decided by bradygaster
+
+📌 Team update (2026-02-11): Diagram standards — Mermaid only, no ASCII art. All diagrams must use Mermaid — decided by Badger, bradygaster
+📌 Team update (2026-02-11): VB.NET respectful framing — never refer to VB.NET negatively, just "we're C# now" — decided by bradygaster
+📌 Team update (2026-02-11): Orleans + SignalR hybrid recommended — 4 grain types for networking layer — decided by Heisenberg
+📌 Team update (2026-02-11): CI pipeline created (.github/workflows/build.yml) targeting src/Terrarium.sln — decided by Hank
+📌 Team update (2026-02-11): CSS token naming: --glass-{category}-{element}-{modifier}, BEM for components — decided by Jesse

--- a/.ai-team/decisions/inbox/saul-aspire-versions.md
+++ b/.ai-team/decisions/inbox/saul-aspire-versions.md
@@ -1,0 +1,18 @@
+# Aspire Package Versions for .NET 10
+
+**By:** Saul (DevOps / Aspire)
+**Date:** 2026-02-11
+**Status:** Implemented
+
+## What
+Aspire AppHost and ServiceDefaults use these package versions:
+- **Aspire.Hosting.AppHost** + **Aspire.AppHost.Sdk**: `13.1.0`
+- **Microsoft.Extensions.ServiceDiscovery**: `10.3.0`
+- **Microsoft.Extensions.Http.Resilience**: `10.3.0`
+- **OpenTelemetry.\***: `1.15.0`
+
+## Why
+- Aspire workload is deprecated in .NET 10 — everything is NuGet-based now
+- These are the latest stable versions as of 2026-02-11
+- All other projects (Server, Web) should reference ServiceDefaults and call `builder.AddServiceDefaults()` + `app.MapDefaultEndpoints()`
+- When Server and Web projects are created, uncomment the ProjectReference and AddProject lines in AppHost

--- a/src/Terrarium.AppHost/Program.cs
+++ b/src/Terrarium.AppHost/Program.cs
@@ -1,3 +1,14 @@
 var builder = DistributedApplication.CreateBuilder(args);
 
+// Terrarium Server — the game's API backend (peer discovery, species registration, etc.)
+// Uncomment when Terrarium.Server project is created:
+// var server = builder.AddProject<Projects.Terrarium_Server>("server");
+
+// Terrarium Web — Blazor frontend for the creature ecosystem
+// Uncomment when Terrarium.Web project is created:
+// builder.AddProject<Projects.Terrarium_Web>("web")
+//     .WithExternalHttpEndpoints()
+//     .WithReference(server)
+//     .WaitFor(server);
+
 builder.Build().Run();

--- a/src/Terrarium.AppHost/Terrarium.AppHost.csproj
+++ b/src/Terrarium.AppHost/Terrarium.AppHost.csproj
@@ -1,11 +1,28 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Terrarium.ServiceDefaults\Terrarium.ServiceDefaults.csproj" IsAspireProjectResource="false" />
+  </ItemGroup>
+
+  <!-- Project references for orchestrated services (uncomment when projects exist)
+  <ItemGroup>
+    <ProjectReference Include="..\Terrarium.Server\Terrarium.Server.csproj" />
+    <ProjectReference Include="..\Terrarium.Web\Terrarium.Web.csproj" />
+  </ItemGroup>
+  -->
 
 </Project>

--- a/src/Terrarium.ServiceDefaults/Extensions.cs
+++ b/src/Terrarium.ServiceDefaults/Extensions.cs
@@ -16,6 +16,10 @@ namespace Microsoft.Extensions.Hosting;
 /// </summary>
 public static class Extensions
 {
+    /// <summary>
+    /// Adds standard service defaults used by all Terrarium services:
+    /// OpenTelemetry (tracing, metrics, logging), health checks, service discovery, and HTTP resilience.
+    /// </summary>
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
     {
         builder.ConfigureOpenTelemetry();
@@ -30,6 +34,9 @@ public static class Extensions
         return builder;
     }
 
+    /// <summary>
+    /// Configures OpenTelemetry with OTLP export for tracing, metrics, and logging.
+    /// </summary>
     public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
     {
         builder.Logging.AddOpenTelemetry(logging =>
@@ -70,6 +77,9 @@ public static class Extensions
         return builder;
     }
 
+    /// <summary>
+    /// Adds default health checks for liveness and readiness.
+    /// </summary>
     public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
     {
         builder.Services.AddHealthChecks()
@@ -78,6 +88,11 @@ public static class Extensions
         return builder;
     }
 
+    /// <summary>
+    /// Maps health check endpoints:
+    /// /health — readiness (all checks)
+    /// /alive  — liveness (only "live" tagged checks)
+    /// </summary>
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
         app.MapHealthChecks("/health");

--- a/src/Terrarium.ServiceDefaults/Terrarium.ServiceDefaults.csproj
+++ b/src/Terrarium.ServiceDefaults/Terrarium.ServiceDefaults.csproj
@@ -1,18 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.3.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #2

Creates the .NET Aspire orchestration layer:
- **Terrarium.AppHost**: Aspire AppHost with Server and Web resources (commented out until those projects exist)
- **Terrarium.ServiceDefaults**: Shared defaults with OpenTelemetry, health checks, service discovery

### Package Versions
- Aspire.Hosting.AppHost + Aspire.AppHost.Sdk: 13.1.0
- Microsoft.Extensions.ServiceDiscovery: 10.3.0
- Microsoft.Extensions.Http.Resilience: 10.3.0
- OpenTelemetry.*: 1.15.0

Run with: `dotnet run --project src/Terrarium.AppHost`