### PR TITLE
Port OrganismBase creature SDK to .NET 10

### DIFF
--- a/.ai-team/decisions/inbox/mike-arraylist-scan-deferred.md
+++ b/.ai-team/decisions/inbox/mike-arraylist-scan-deferred.md
@@ -1,0 +1,20 @@
+# Decision: Keep ArrayList Scan() for Now
+
+**Author:** Mike (Networking / Engine Dev)
+**Date:** 2026-02-10
+**Status:** Proposed
+
+## Context
+
+The legacy `IAnimalWorldBoundary.Scan()` method returns `System.Collections.ArrayList`. This is a non-generic collection from .NET 1.0 days.
+
+## Decision
+
+I kept `ArrayList` as the return type for `Scan()` because:
+1. The Game project (which implements this interface) hasn't been ported yet
+2. Changing it to `List<OrganismState>` now would create a compile-time dependency on the Game project's port
+3. It preserves source-level compatibility with existing creature code that casts from ArrayList
+
+## Action Required
+
+When the Game project is ported (whoever picks that up), `IAnimalWorldBoundary.Scan()` should be changed to return `List<OrganismState>` and the `using System.Collections` import can be removed from the interface file.

--- a/src/Terrarium.OrganismBase/Actions/Action.cs
+++ b/src/Terrarium.OrganismBase/Actions/Action.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Base class for all actions a creature can perform.
+/// </summary>
+public abstract class Action
+{
+    internal Action(string organismID, int actionID)
+    {
+        OrganismID = organismID;
+        ActionID = actionID;
+    }
+
+    public string OrganismID { get; private set; }
+
+    public int ActionID { get; private set; }
+}

--- a/src/Terrarium.OrganismBase/Actions/AttackAction.cs
+++ b/src/Terrarium.OrganismBase/Actions/AttackAction.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents a command to attack another creature.
+/// </summary>
+public class AttackAction : Action
+{
+    internal AttackAction(string organismID, int actionID, AnimalState targetAnimal) : base(organismID, actionID)
+    {
+        TargetAnimal = targetAnimal;
+    }
+
+    public AnimalState TargetAnimal { get; private set; }
+
+    public override string ToString()
+    {
+        return string.Format("TargetAnimal={0}", TargetAnimal.ID);
+    }
+}

--- a/src/Terrarium.OrganismBase/Actions/DefendAction.cs
+++ b/src/Terrarium.OrganismBase/Actions/DefendAction.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents a command to defend against an attack.
+/// </summary>
+public class DefendAction : Action
+{
+    internal DefendAction(string organismID, int actionID, AnimalState targetAnimal) : base(organismID, actionID)
+    {
+        TargetAnimal = targetAnimal;
+    }
+
+    public AnimalState TargetAnimal { get; private set; }
+
+    public override string ToString()
+    {
+        return string.Format("TargetAnimal={0}", TargetAnimal.ID);
+    }
+}

--- a/src/Terrarium.OrganismBase/Actions/EatAction.cs
+++ b/src/Terrarium.OrganismBase/Actions/EatAction.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents a command to eat another creature or plant.
+/// </summary>
+public class EatAction : Action
+{
+    internal EatAction(string organismID, int actionID, OrganismState targetOrganism) : base(organismID, actionID)
+    {
+        TargetOrganism = targetOrganism;
+    }
+
+    public OrganismState TargetOrganism { get; private set; }
+
+    public override string ToString()
+    {
+        return string.Format("TargetOrganism={0}", TargetOrganism.ID);
+    }
+}

--- a/src/Terrarium.OrganismBase/Actions/MoveToAction.cs
+++ b/src/Terrarium.OrganismBase/Actions/MoveToAction.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents a movement command.
+/// </summary>
+public class MoveToAction : Action
+{
+    internal MoveToAction(string organismID, int actionID, MovementVector moveTo) : base(organismID, actionID)
+    {
+        MovementVector = moveTo;
+    }
+
+    public MovementVector MovementVector { get; private set; }
+
+    public override string ToString()
+    {
+        return MovementVector.ToString();
+    }
+}

--- a/src/Terrarium.OrganismBase/Actions/ReproduceAction.cs
+++ b/src/Terrarium.OrganismBase/Actions/ReproduceAction.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents a command to reproduce.
+/// </summary>
+public class ReproduceAction : Action
+{
+    private readonly byte[]? _dna;
+
+    internal ReproduceAction(string organismID, int actionID, byte[]? dna) : base(organismID, actionID)
+    {
+        _dna = dna;
+    }
+
+    public byte[]? Dna
+    {
+        get
+        {
+            if (_dna != null)
+                return (byte[])_dna.Clone();
+            return null;
+        }
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/Animal.cs
+++ b/src/Terrarium.OrganismBase/Creature/Animal.cs
@@ -1,0 +1,305 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Collections;
+using System.IO;
+
+namespace OrganismBase;
+
+/// <summary>
+/// This is the class that you derive from when you create an animal.
+/// </summary>
+public abstract class Animal : Organism
+{
+    private AntennaState antennaState = new AntennaState((AntennaState?)null);
+
+    internal IAnimalWorldBoundary World => (IAnimalWorldBoundary)OrganismWorldBoundary!;
+
+    public AntennaState Antennas
+    {
+        get => antennaState;
+        set => antennaState = value;
+    }
+
+    public int WorldWidth => World.WorldWidth;
+
+    public int WorldHeight => World.WorldHeight;
+
+    public new AnimalState State => World.CurrentAnimalState;
+
+    public IAnimalSpecies Species => (IAnimalSpecies)State.Species;
+
+    public MoveToAction? CurrentMoveToAction =>
+        PendingActions.MoveToAction ?? InProgressActions.MoveToAction;
+
+    public Boolean IsMoving => CurrentMoveToAction != null;
+
+    public DefendAction? CurrentDefendAction =>
+        PendingActions.DefendAction ?? InProgressActions.DefendAction;
+
+    public Boolean IsDefending => CurrentDefendAction != null;
+
+    public AttackAction? CurrentAttackAction =>
+        PendingActions.AttackAction ?? InProgressActions.AttackAction;
+
+    public Boolean IsAttacking => CurrentAttackAction != null;
+
+    public EatAction? CurrentEatAction =>
+        PendingActions.EatAction ?? InProgressActions.EatAction;
+
+    public Boolean IsEating => CurrentEatAction != null;
+
+    public Boolean CanEat => State.EnergyState <= EnergyState.Normal;
+
+    public event MoveCompletedEventHandler? MoveCompleted;
+    public event AttackCompletedEventHandler? AttackCompleted;
+    public event EatCompletedEventHandler? EatCompleted;
+    public event IdleEventHandler? Idle;
+    public event LoadEventHandler? Load;
+    public event TeleportedEventHandler? Teleported;
+    public event ReproduceCompletedEventHandler? ReproduceCompleted;
+    public event BornEventHandler? Born;
+    public event DefendCompletedEventHandler? DefendCompleted;
+    public event AttackedEventHandler? Attacked;
+
+    public abstract void SerializeAnimal(MemoryStream m);
+    public abstract void DeserializeAnimal(MemoryStream m);
+
+    public void InternalAnimalSerialize(MemoryStream m) { }
+    public void InternalAnimalDeserialize(MemoryStream m) { }
+
+    public ArrayList Scan() => World.Scan();
+
+    public OrganismState? RefreshState(string organismID)
+    {
+        if (organismID == null)
+            throw new ArgumentNullException(nameof(organismID), "The argument 'organismID' cannot be null");
+        return World.RefreshState(organismID);
+    }
+
+    public OrganismState? LookFor(OrganismState organismState)
+    {
+        if (organismState == null)
+            throw new ArgumentNullException(nameof(organismState), "The argument 'organismState' cannot be null");
+        return World.LookFor(organismState);
+    }
+
+    public Boolean IsMySpecies(OrganismState targetState)
+    {
+        if (targetState == null)
+            throw new ArgumentNullException(nameof(targetState), "The argument 'targetState' cannot be null");
+        return State.Species.IsSameSpecies(targetState.Species);
+    }
+
+    public void StopMoving()
+    {
+        lock (PendingActions)
+        {
+            PendingActions.SetMoveToAction(null);
+            InProgressActions.SetMoveToAction(null);
+        }
+    }
+
+    public void BeginMoving(MovementVector vector)
+    {
+        if (vector == null)
+            throw new ArgumentNullException(nameof(vector), "The argument 'vector' cannot be null");
+
+        if (vector.Speed > State.AnimalSpecies.MaximumSpeed)
+            throw new TooFastException();
+
+        if (vector.Destination.X > World.WorldWidth - 1 ||
+            vector.Destination.X < 0 ||
+            vector.Destination.Y > World.WorldHeight - 1 ||
+            vector.Destination.Y < 0)
+        {
+            throw new OutOfBoundsException();
+        }
+
+        var actionID = GetNextActionID();
+        var action = new MoveToAction(ID, actionID, vector);
+        lock (PendingActions)
+        {
+            PendingActions.SetMoveToAction(action);
+            InProgressActions.SetMoveToAction(action);
+        }
+    }
+
+    public void BeginDefending(AnimalState targetAnimal)
+    {
+        if (targetAnimal == null)
+            throw new ArgumentNullException(nameof(targetAnimal), "The argument 'targetAnimal' cannot be null");
+
+        var actionID = GetNextActionID();
+        var action = new DefendAction(ID, actionID, targetAnimal);
+        lock (PendingActions)
+        {
+            PendingActions.SetDefendAction(action);
+            InProgressActions.SetDefendAction(action);
+        }
+    }
+
+    public void BeginAttacking(AnimalState targetAnimal)
+    {
+        if (targetAnimal == null)
+            throw new ArgumentNullException(nameof(targetAnimal), "The argument 'targetAnimal' cannot be null");
+
+        if (!CanAttack(targetAnimal))
+            throw new NotHungryException();
+
+        var actionID = GetNextActionID();
+        var action = new AttackAction(ID, actionID, targetAnimal);
+        lock (PendingActions)
+        {
+            PendingActions.SetAttackAction(action);
+            InProgressActions.SetAttackAction(action);
+        }
+    }
+
+    public Boolean WithinEatingRange(OrganismState targetOrganism)
+    {
+        if (targetOrganism == null)
+            throw new ArgumentNullException(nameof(targetOrganism), "The argument 'targetOrganism' cannot be null");
+        return State.IsAdjacentOrOverlapping(targetOrganism);
+    }
+
+    public Boolean WithinAttackingRange(AnimalState targetOrganism)
+    {
+        if (targetOrganism == null)
+            throw new ArgumentNullException(nameof(targetOrganism), "The argument 'targetOrganism' cannot be null");
+        return State.IsWithinRect(1, targetOrganism);
+    }
+
+    public void BeginEating(OrganismState targetOrganism)
+    {
+        if (targetOrganism == null)
+            throw new ArgumentNullException(nameof(targetOrganism), "The argument 'targetOrganism' cannot be null");
+
+        if (State.EnergyState > EnergyState.Normal)
+            throw new AlreadyFullException();
+
+        var currentOrganism = World.LookForNoCamouflage(targetOrganism);
+        if (currentOrganism == null)
+            throw new NotVisibleException();
+        if (!WithinEatingRange(currentOrganism))
+            throw new NotWithinDistanceException();
+
+        if (State.AnimalSpecies.IsCarnivore)
+        {
+            if (currentOrganism is PlantState)
+                throw new ImproperFoodException();
+            if (currentOrganism.IsAlive)
+                throw new NotDeadException();
+        }
+        else
+        {
+            if (currentOrganism is AnimalState)
+                throw new ImproperFoodException();
+        }
+
+        var actionID = GetNextActionID();
+        var action = new EatAction(ID, actionID, targetOrganism);
+        lock (PendingActions)
+        {
+            PendingActions.SetEatAction(action);
+            InProgressActions.SetEatAction(action);
+        }
+    }
+
+    public Boolean CanAttack(AnimalState targetAnimal)
+    {
+        if (State.AnimalSpecies.IsCarnivore) return true;
+
+        if (targetAnimal == null)
+            throw new ArgumentNullException(nameof(targetAnimal), "The argument 'targetAnimal' cannot be null");
+
+        var wasAttacked = false;
+        foreach (var attackEvent in State.OrganismEvents!.AttackedEvents)
+        {
+            if (attackEvent.Attacker.ID != targetAnimal.ID) continue;
+            wasAttacked = true;
+            break;
+        }
+
+        return wasAttacked || State.EnergyState <= EnergyState.Hungry;
+    }
+
+    public override sealed void InternalMain(bool clearOnly)
+    {
+        if (!IsInitialized)
+        {
+            Initialize();
+            IsInitialized = true;
+        }
+
+        WriteTrace("#Load");
+        OnLoad(new LoadEventArgs(), clearOnly);
+
+        var events = State.OrganismEvents;
+        if (events != null)
+        {
+            if (events.MoveCompleted != null) OnMoveCompleted(events.MoveCompleted, clearOnly);
+            if (events.AttackCompleted != null) OnAttackCompleted(events.AttackCompleted, clearOnly);
+            if (events.EatCompleted != null) OnEatCompleted(events.EatCompleted, clearOnly);
+            if (events.Teleported != null) OnTeleported(events.Teleported, clearOnly);
+            if (events.ReproduceCompleted != null) OnReproduceCompleted(events.ReproduceCompleted, clearOnly);
+            if (events.Born != null) OnBorn(events.Born, clearOnly);
+            if (events.DefendCompleted != null) OnDefendCompleted(events.DefendCompleted, clearOnly);
+            if (events.AttackedEvents.Count > 0)
+            {
+                foreach (var attackEvent in events.AttackedEvents)
+                {
+                    OnAttacked(attackEvent, clearOnly);
+                }
+            }
+        }
+
+        WriteTrace("#Idle");
+        OnIdle(new IdleEventArgs(), clearOnly);
+
+        if (clearOnly) InternalTurnsSkipped++;
+        else InternalTurnsSkipped = 0;
+    }
+
+    private void OnBorn(BornEventArgs e, bool clearOnly) { if (!clearOnly) Born?.Invoke(this, e); }
+    private void OnAttacked(AttackedEventArgs e, bool clearOnly) { if (!clearOnly) Attacked?.Invoke(this, e); }
+    private void OnIdle(IdleEventArgs e, bool clearOnly) { if (!clearOnly) Idle?.Invoke(this, e); }
+    private void OnLoad(LoadEventArgs e, bool clearOnly) { if (!clearOnly) Load?.Invoke(this, e); }
+
+    private void OnReproduceCompleted(ReproduceCompletedEventArgs e, bool clearOnly)
+    {
+        if (InProgressActions.ReproduceAction != null && e.ActionID == InProgressActions.ReproduceAction.ActionID)
+            InProgressActions.SetReproduceAction(null);
+        if (!clearOnly) ReproduceCompleted?.Invoke(this, e);
+    }
+
+    private void OnDefendCompleted(DefendCompletedEventArgs e, bool clearOnly)
+    {
+        if (InProgressActions.DefendAction != null && e.ActionID == InProgressActions.DefendAction.ActionID)
+            InProgressActions.SetDefendAction(null);
+        if (!clearOnly) DefendCompleted?.Invoke(this, e);
+    }
+
+    private void OnTeleported(TeleportedEventArgs e, bool clearOnly) { if (!clearOnly) Teleported?.Invoke(this, e); }
+
+    private void OnMoveCompleted(MoveCompletedEventArgs e, bool clearOnly)
+    {
+        if (InProgressActions.MoveToAction != null && e.ActionID == InProgressActions.MoveToAction.ActionID)
+            InProgressActions.SetMoveToAction(null);
+        if (!clearOnly) MoveCompleted?.Invoke(this, e);
+    }
+
+    private void OnAttackCompleted(AttackCompletedEventArgs e, bool clearOnly)
+    {
+        if (InProgressActions.AttackAction != null && e.ActionID == InProgressActions.AttackAction.ActionID)
+            InProgressActions.SetAttackAction(null);
+        if (!clearOnly) AttackCompleted?.Invoke(this, e);
+    }
+
+    private void OnEatCompleted(EatCompletedEventArgs e, bool clearOnly)
+    {
+        if (InProgressActions.EatAction != null && e.ActionID == InProgressActions.EatAction.ActionID)
+            InProgressActions.SetEatAction(null);
+        if (!clearOnly) EatCompleted?.Invoke(this, e);
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/AntennaState.cs
+++ b/src/Terrarium.OrganismBase/Creature/AntennaState.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Provides access to a creature's Antenna. Each creature has two
+/// Antenna that can be placed in 10 different positions each.
+/// </summary>
+public class AntennaState
+{
+    private bool immutable;
+    private AntennaPosition leftAntenna;
+    private AntennaPosition rightAntenna;
+
+    public AntennaState(AntennaState? state)
+    {
+        leftAntenna = AntennaPosition.Left;
+        rightAntenna = AntennaPosition.Left;
+
+        if (state != null)
+        {
+            if (VerifyAntenna(state.LeftAntenna))
+                leftAntenna = state.LeftAntenna;
+
+            if (VerifyAntenna(state.RightAntenna))
+                rightAntenna = state.RightAntenna;
+        }
+    }
+
+    public AntennaState(AntennaPosition left, AntennaPosition right)
+    {
+        leftAntenna = VerifyAntenna(left) ? left : AntennaPosition.Left;
+        rightAntenna = VerifyAntenna(right) ? right : AntennaPosition.Left;
+    }
+
+    public AntennaPosition LeftAntenna
+    {
+        get => leftAntenna;
+        set
+        {
+            if (!immutable && VerifyAntenna(value))
+                leftAntenna = value;
+        }
+    }
+
+    public AntennaPosition RightAntenna
+    {
+        get => rightAntenna;
+        set
+        {
+            if (!immutable && VerifyAntenna(value))
+                rightAntenna = value;
+        }
+    }
+
+    public int AntennaValue
+    {
+        get
+        {
+            var leftVal = (int)leftAntenna;
+            var rightVal = (int)rightAntenna;
+            return leftVal * 10 + rightVal;
+        }
+        set
+        {
+            if (!immutable && value >= 0 && value < 100)
+            {
+                leftAntenna = (AntennaPosition)(value / 10);
+                rightAntenna = (AntennaPosition)(value % 10);
+            }
+        }
+    }
+
+    public void MakeImmutable()
+    {
+        immutable = true;
+    }
+
+    private static bool VerifyAntenna(AntennaPosition pos)
+    {
+        var antennaValue = (int)pos;
+        return antennaValue >= 0 && antennaValue < 10;
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/AttackedEventArgsCollection.cs
+++ b/src/Terrarium.OrganismBase/Creature/AttackedEventArgsCollection.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Collections.Generic;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Collection of AttackedEventArgs for a creature's tick.
+/// </summary>
+public class AttackedEventArgsCollection
+{
+    private readonly List<AttackedEventArgs> _innerList = new List<AttackedEventArgs>();
+
+    internal AttackedEventArgsCollection() { }
+
+    internal Boolean IsImmutable { get; private set; }
+
+    public AttackedEventArgs this[int index] => _innerList[index];
+
+    public int Count => _innerList.Count;
+
+    internal void MakeImmutable()
+    {
+        IsImmutable = true;
+    }
+
+    public void Add(AttackedEventArgs attackedEventArgs)
+    {
+        if (IsImmutable)
+        {
+            throw new ApplicationException("Object is immutable.");
+        }
+
+        _innerList.Add(attackedEventArgs);
+    }
+
+    public IEnumerator<AttackedEventArgs> GetEnumerator() => _innerList.GetEnumerator();
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/AnimalSkinAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/AnimalSkinAttribute.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Determines the skin used to display an animal on screen.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class AnimalSkinAttribute : Attribute
+{
+    public AnimalSkinAttribute(string skin)
+    {
+        SkinFamily = AnimalSkinFamily.Ant;
+        Skin = skin;
+    }
+
+    public AnimalSkinAttribute(AnimalSkinFamily skinFamily)
+    {
+        Skin = string.Empty;
+        SkinFamily = skinFamily;
+    }
+
+    public AnimalSkinAttribute(AnimalSkinFamily skinFamily, string skin)
+    {
+        SkinFamily = skinFamily;
+        Skin = skin;
+    }
+
+    public string Skin { get; private set; }
+    public AnimalSkinFamily SkinFamily { get; private set; }
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/AttackDamagePointsAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/AttackDamagePointsAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Maximum damage your animal can inflict with one attack.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class AttackDamagePointsAttribute : PointBasedCharacteristicAttribute
+{
+    public AttackDamagePointsAttribute(int attackPoints)
+        : base(attackPoints, EngineSettings.MaximumInflictedDamagePerUnitOfRadius) { }
+
+    public int MaximumAttackDamagePerUnitRadius => (int)((EngineSettings.BaseInflictedDamagePerUnitOfRadius + PercentOfMaximum * EngineSettings.MaximumInflictedDamagePerUnitOfRadius) + 0.001f);
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/AuthorInformationAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/AuthorInformationAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Required attribute to identify a creature's author.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly, Inherited = true, AllowMultiple = false)]
+public sealed class AuthorInformationAttribute : Attribute
+{
+    public AuthorInformationAttribute(string authorName)
+    {
+        AuthorName = authorName;
+        AuthorEmail = "";
+    }
+
+    public AuthorInformationAttribute(string authorName, string authorEmail)
+    {
+        AuthorName = authorName;
+        AuthorEmail = authorEmail;
+    }
+
+    public string AuthorName { get; private set; }
+    public string AuthorEmail { get; private set; }
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/CamouflagePointsAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/CamouflagePointsAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Determines how easily your animal can be seen by other animals.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class CamouflagePointsAttribute : PointBasedCharacteristicAttribute
+{
+    public CamouflagePointsAttribute(int camouflagePoints)
+        : base(camouflagePoints, EngineSettings.InvisibleOddsMaximum) { }
+
+    public int InvisibleOdds => (int)(EngineSettings.InvisibleOddsBase + PercentOfMaximum * EngineSettings.InvisibleOddsMaximum);
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/CarnivoreAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/CarnivoreAttribute.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Chooses whether your animal is an herbivore or a carnivore.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class CarnivoreAttribute : Attribute
+{
+    public CarnivoreAttribute(Boolean isCarnivore)
+    {
+        IsCarnivore = isCarnivore;
+    }
+
+    public bool IsCarnivore { get; private set; }
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/DefendDamagePointsAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/DefendDamagePointsAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Maximum damage your animal can defend against.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class DefendDamagePointsAttribute : PointBasedCharacteristicAttribute
+{
+    public DefendDamagePointsAttribute(int defensePoints)
+        : base(defensePoints, EngineSettings.MaximumDefendedDamagePerUnitOfRadius) { }
+
+    public int MaximumDefendDamagePerUnitRadius => (int)((EngineSettings.BaseDefendedDamagePerUnitOfRadius + PercentOfMaximum * EngineSettings.MaximumDefendedDamagePerUnitOfRadius) + 0.001f);
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/EatingSpeedPointsAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/EatingSpeedPointsAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Determines how quickly your animal can eat.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class EatingSpeedPointsAttribute : PointBasedCharacteristicAttribute
+{
+    public EatingSpeedPointsAttribute(int eatingSpeedPoints)
+        : base(eatingSpeedPoints, EngineSettings.MaximumEatingSpeedPerUnitOfRadius) { }
+
+    public int EatingSpeedPerUnitRadius => (int)(EngineSettings.BaseEatingSpeedPerUnitOfRadius + PercentOfMaximum * EngineSettings.MaximumEatingSpeedPerUnitOfRadius);
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/EyesightPointsAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/EyesightPointsAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Determines how far your animal can see.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class EyesightPointsAttribute : PointBasedCharacteristicAttribute
+{
+    public EyesightPointsAttribute(int eyesightPoints)
+        : base(eyesightPoints, EngineSettings.MaximumEyesightRadius) { }
+
+    public int EyesightRadius => (int)(EngineSettings.BaseEyesightRadius + PercentOfMaximum * EngineSettings.MaximumEyesightRadius);
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/MarkingColorAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/MarkingColorAttribute.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Drawing;
+
+namespace OrganismBase;
+
+/// <summary>Determines the color used for special markings on the organism.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class MarkingColorAttribute : Attribute
+{
+    public MarkingColorAttribute(KnownColor markingColor)
+    {
+        MarkingColor = markingColor;
+    }
+
+    public KnownColor MarkingColor { get; private set; }
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/MatureSizeAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/MatureSizeAttribute.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Determines how large your organism will be.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class MatureSizeAttribute : Attribute
+{
+    private readonly int _matureSize;
+
+    public MatureSizeAttribute(int matureSize)
+    {
+        if (matureSize > EngineSettings.MaxMatureSize || matureSize < EngineSettings.MinMatureSize)
+        {
+            throw new SizeOutOfRangeCharacteristicException();
+        }
+
+        _matureSize = matureSize;
+    }
+
+    public int MatureRadius => _matureSize / 2;
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/MaximumEnergyPointsAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/MaximumEnergyPointsAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Determines how much energy your animal can store.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class MaximumEnergyPointsAttribute : PointBasedCharacteristicAttribute
+{
+    public MaximumEnergyPointsAttribute(int maximumEnergyPoints)
+        : base(maximumEnergyPoints, (int)EngineSettings.MaxEnergyMaximumPerUnitRadius) { }
+
+    public int MaximumEnergyPerUnitRadius => (int)((float)EngineSettings.MaxEnergyBasePerUnitRadius + PercentOfMaximum * (float)EngineSettings.MaxEnergyMaximumPerUnitRadius);
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/MaximumSpeedPointsAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/MaximumSpeedPointsAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Determines the top speed your animal can attain.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class MaximumSpeedPointsAttribute : PointBasedCharacteristicAttribute
+{
+    public MaximumSpeedPointsAttribute(int speedPoints)
+        : base(speedPoints, EngineSettings.SpeedMaximum) { }
+
+    public int MaximumSpeed => (int)(EngineSettings.SpeedBase + PercentOfMaximum * EngineSettings.SpeedMaximum);
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/OrganismClassAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/OrganismClassAttribute.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Identifies the class in the assembly that derives from Plant or Animal.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly, Inherited = true, AllowMultiple = false)]
+public sealed class OrganismClassAttribute : Attribute
+{
+    public OrganismClassAttribute(string className)
+    {
+        ClassName = className;
+    }
+
+    public string ClassName { get; private set; }
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/PlantSkinAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/PlantSkinAttribute.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Determines the skin used to display a plant on screen.</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class PlantSkinAttribute : Attribute
+{
+    public PlantSkinAttribute(string skin)
+    {
+        SkinFamily = PlantSkinFamily.Plant;
+        Skin = skin;
+    }
+
+    public PlantSkinAttribute(PlantSkinFamily skinFamily)
+    {
+        Skin = string.Empty;
+        SkinFamily = skinFamily;
+    }
+
+    public PlantSkinAttribute(PlantSkinFamily skinFamily, string skin)
+    {
+        SkinFamily = skinFamily;
+        Skin = skin;
+    }
+
+    public string Skin { get; private set; }
+    public PlantSkinFamily SkinFamily { get; private set; }
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/PointBasedCharacteristicAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/PointBasedCharacteristicAttribute.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Base class for point-based creature characteristic attributes.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public abstract class PointBasedCharacteristicAttribute : Attribute
+{
+    private readonly int _maximumValue;
+    private readonly int _originalPoints;
+
+    protected PointBasedCharacteristicAttribute(int points, int maximumValue)
+    {
+        _originalPoints = points;
+        _maximumValue = maximumValue;
+
+        if (points > EngineSettings.MaxAvailableCharacteristicPoints || points < 0)
+        {
+            throw new TooManyPointsOnOneCharacteristicException();
+        }
+
+        Points = points;
+    }
+
+    public int Points { get; private set; }
+
+    internal float PercentOfMaximum => Points / (float)EngineSettings.MaxAvailableCharacteristicPoints;
+
+    public string GetWarnings()
+    {
+        if ((_maximumValue / (double)EngineSettings.MaxAvailableCharacteristicPoints) < 1)
+        {
+            var pointsToIncrement = EngineSettings.MaxAvailableCharacteristicPoints / _maximumValue;
+            if (_originalPoints % pointsToIncrement != 0)
+            {
+                return "Points applied to '" + GetType().Name + "' should be in increments of " + pointsToIncrement +
+                       ".  Anything else is wasted.";
+            }
+        }
+
+        return string.Empty;
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/Attributes/SeedSpreadDistanceAttribute.cs
+++ b/src/Terrarium.OrganismBase/Creature/Attributes/SeedSpreadDistanceAttribute.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>Controls the distance that a plant can spread its seeds (not currently used).</summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+public sealed class SeedSpreadDistanceAttribute : Attribute
+{
+    public SeedSpreadDistanceAttribute(int seedSpreadDistance)
+    {
+        if (seedSpreadDistance > EngineSettings.MaxSeedSpreadDistance)
+        {
+            throw new ApplicationException(
+                "You have placed too many points into SeedSpreadDistance.  Please limit this number to " +
+                EngineSettings.MaxSeedSpreadDistance + ".");
+        }
+
+        SeedSpreadDistance = seedSpreadDistance;
+    }
+
+    public int SeedSpreadDistance { get; private set; }
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/ActionResponseEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/ActionResponseEventArgs.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Base class for events that are in response to an action.
+/// </summary>
+public abstract class ActionResponseEventArgs : OrganismEventArgs
+{
+    protected ActionResponseEventArgs(int actionID, Action action)
+    {
+        ActionID = actionID;
+        Action = action;
+    }
+
+    public int ActionID { get; private set; }
+
+    public Action Action { get; private set; }
+
+    public override string ToString()
+    {
+        return Action.ToString()!;
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/AttackCompletedEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/AttackCompletedEventArgs.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the AttackCompleted event.
+/// </summary>
+public class AttackCompletedEventArgs : ActionResponseEventArgs
+{
+    public AttackCompletedEventArgs(int actionID, Action action, Boolean killed, Boolean escaped,
+                                    int inflictedDamage) : base(actionID, action)
+    {
+        InflictedDamage = inflictedDamage;
+        Escaped = escaped;
+        Killed = killed;
+    }
+
+    public AttackAction AttackAction => (AttackAction)Action;
+
+    public int InflictedDamage { get; private set; }
+
+    public bool Killed { get; private set; }
+
+    public bool Escaped { get; private set; }
+
+    public override string ToString()
+    {
+        return string.Format("#AttackCompleted {{InflictedDamage={0}, Killed={1}, Escaped={2}, {3}}}",
+                             InflictedDamage, Killed, Escaped, base.ToString());
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/AttackedEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/AttackedEventArgs.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the Attacked event, containing the state of the attacking creature.
+/// </summary>
+public class AttackedEventArgs : OrganismEventArgs
+{
+    public AttackedEventArgs(AnimalState attacker)
+    {
+        Attacker = attacker;
+    }
+
+    public AnimalState Attacker { get; private set; }
+
+    public override string ToString()
+    {
+        return string.Format("#Attacked {{Attacker = {0}}}", Attacker.ID);
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/BornEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/BornEventArgs.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the Born event, containing DNA from the parent.
+/// </summary>
+public class BornEventArgs : OrganismEventArgs
+{
+    public BornEventArgs(byte[]? dna)
+    {
+        Dna = dna;
+    }
+
+    public byte[]? Dna { get; private set; }
+
+    public override string ToString() => "#Born";
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/DefendCompletedEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/DefendCompletedEventArgs.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the DefendCompleted event.
+/// </summary>
+public class DefendCompletedEventArgs : ActionResponseEventArgs
+{
+    public DefendCompletedEventArgs(int actionID, Action action) : base(actionID, action) { }
+
+    public DefendAction DefendAction => (DefendAction)Action;
+
+    public override string ToString()
+    {
+        return string.Format("#DefendCompleted {{{0}}}", base.ToString());
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/EatCompletedEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/EatCompletedEventArgs.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the EatCompleted event.
+/// </summary>
+public class EatCompletedEventArgs : ActionResponseEventArgs
+{
+    public EatCompletedEventArgs(int actionID, Action action, Boolean successful) : base(actionID, action)
+    {
+        Successful = successful;
+    }
+
+    public EatAction EatAction => (EatAction)Action;
+
+    public bool Successful { get; private set; }
+
+    public override string ToString()
+    {
+        return string.Format("#EatCompleted {{Successful={0}, {1}}}", Successful, base.ToString());
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/IdleEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/IdleEventArgs.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the Idle event.
+/// </summary>
+public class IdleEventArgs : OrganismEventArgs
+{
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/LoadEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/LoadEventArgs.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the Load event.
+/// </summary>
+public class LoadEventArgs : OrganismEventArgs
+{
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/MoveCompletedEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/MoveCompletedEventArgs.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the MoveCompleted event.
+/// </summary>
+public class MoveCompletedEventArgs : ActionResponseEventArgs
+{
+    public MoveCompletedEventArgs(int actionID, Action action, ReasonForStop reason,
+                                  OrganismState? blockingOrganism) : base(actionID, action)
+    {
+        Reason = reason;
+        BlockingOrganism = blockingOrganism;
+    }
+
+    public MoveToAction MoveToAction => (MoveToAction)Action;
+
+    public ReasonForStop Reason { get; private set; }
+
+    public OrganismState? BlockingOrganism { get; private set; }
+
+    public override string ToString()
+    {
+        return string.Format("#MoveCompleted {{Reason={0}, {1}}}", Reason, base.ToString());
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/OrganismEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/OrganismEventArgs.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Base class for organism event arguments.
+/// </summary>
+public class OrganismEventArgs : EventArgs
+{
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/ReproduceCompletedEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/ReproduceCompletedEventArgs.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the ReproduceCompleted event.
+/// </summary>
+public class ReproduceCompletedEventArgs : ActionResponseEventArgs
+{
+    public ReproduceCompletedEventArgs(int actionID, Action action) : base(actionID, action) { }
+
+    public ReproduceAction ReproduceAction => (ReproduceAction)Action;
+
+    public override string ToString()
+    {
+        return string.Format("#ReproduceCompleted {{{0}}}", base.ToString());
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/EventArgs/TeleportedEventArgs.cs
+++ b/src/Terrarium.OrganismBase/Creature/EventArgs/TeleportedEventArgs.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Arguments for the Teleported event.
+/// </summary>
+public class TeleportedEventArgs : OrganismEventArgs
+{
+    public TeleportedEventArgs(bool localOnly)
+    {
+        LocalTeleport = localOnly;
+    }
+
+    public bool LocalTeleport { get; private set; }
+
+    public override string ToString()
+    {
+        return string.Format("#Teleported - (Local = {0})", LocalTeleport);
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/Events/AttackCompletedEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/AttackCompletedEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the AttackCompleted event.
+/// </summary>
+public delegate void AttackCompletedEventHandler(object sender, AttackCompletedEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/AttackedEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/AttackedEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the Attacked event.
+/// </summary>
+public delegate void AttackedEventHandler(object sender, AttackedEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/BornEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/BornEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the Born event.
+/// </summary>
+public delegate void BornEventHandler(object sender, BornEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/DefendCompletedEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/DefendCompletedEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the DefendCompleted event.
+/// </summary>
+public delegate void DefendCompletedEventHandler(object sender, DefendCompletedEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/EatCompletedEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/EatCompletedEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the EatCompleted event.
+/// </summary>
+public delegate void EatCompletedEventHandler(object sender, EatCompletedEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/IdleEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/IdleEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the Idle event.
+/// </summary>
+public delegate void IdleEventHandler(object sender, IdleEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/LoadEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/LoadEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the Load event.
+/// </summary>
+public delegate void LoadEventHandler(object sender, LoadEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/MoveCompletedEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/MoveCompletedEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the MoveCompleted event.
+/// </summary>
+public delegate void MoveCompletedEventHandler(object sender, MoveCompletedEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/ReproduceCompletedEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/ReproduceCompletedEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the ReproduceCompleted event.
+/// </summary>
+public delegate void ReproduceCompletedEventHandler(object sender, ReproduceCompletedEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/TeleportedEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/TeleportedEventHandler.cs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Delegate for the Teleported event.
+/// </summary>
+public delegate void TeleportedEventHandler(object sender, TeleportedEventArgs e);

--- a/src/Terrarium.OrganismBase/Creature/Events/TraceEventHandler.cs
+++ b/src/Terrarium.OrganismBase/Creature/Events/TraceEventHandler.cs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>For system use only.</summary>
+public delegate void TraceEventHandler(object sender, params object[] items);

--- a/src/Terrarium.OrganismBase/Creature/Organism.cs
+++ b/src/Terrarium.OrganismBase/Creature/Organism.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Drawing;
+using System.IO;
+
+namespace OrganismBase;
+
+/// <summary>
+/// The Organism class is the base class for the Animal/Plant classes.
+/// </summary>
+public abstract class Organism
+{
+    private readonly PendingActions inProgressActions = new PendingActions();
+    private readonly Random random;
+    private int nextActionID;
+    private PendingActions pendingActions = new PendingActions();
+
+    protected Organism()
+    {
+        random = new Random(GetHashCode());
+    }
+
+    public TraceEventHandler? Trace { get; set; }
+
+    internal bool IsInitialized { get; set; }
+
+    internal IOrganismWorldBoundary? OrganismWorldBoundary { get; private set; }
+
+    public MemoryStream? SerializedStream { get; set; }
+
+    public Random OrganismRandom => random;
+
+    public Point Position => OrganismWorldBoundary!.CurrentOrganismState.Position;
+
+    public OrganismState State => OrganismWorldBoundary!.CurrentOrganismState;
+
+    public int TurnsSkipped { get; private set; }
+
+    internal int InternalTurnsSkipped
+    {
+        get => TurnsSkipped;
+        set => TurnsSkipped = value;
+    }
+
+    public Boolean CanReproduce =>
+        State.ReadyToReproduce && !IsReproducing &&
+        State.IsMature && (State.EnergyState >= EnergyState.Normal);
+
+    public ReproduceAction? CurrentReproduceAction =>
+        PendingActions.ReproduceAction ?? InProgressActions.ReproduceAction;
+
+    public Boolean IsReproducing => CurrentReproduceAction != null;
+
+    public string ID => OrganismWorldBoundary!.ID;
+
+    internal PendingActions PendingActions => pendingActions;
+
+    internal PendingActions InProgressActions => inProgressActions;
+
+    internal Boolean IsTracing => Trace != null;
+
+    protected virtual void Initialize() { }
+
+    public void SetWorldBoundary(IOrganismWorldBoundary boundary)
+    {
+        if (OrganismWorldBoundary != null) return;
+        OrganismWorldBoundary = boundary;
+    }
+
+    public double DistanceTo(OrganismState organismState)
+    {
+        if (organismState == null)
+            throw new ArgumentNullException(nameof(organismState), "The argument 'organismState' cannot be null");
+
+        return Vector.Subtract(Position, organismState.Position).Magnitude;
+    }
+
+    public void BeginReproduction(byte[]? dna)
+    {
+        if (IsReproducing) throw new AlreadyReproducingException();
+        if (!State.IsMature) throw new NotMatureException();
+        if (State.EnergyState < EnergyState.Normal) throw new NotEnoughEnergyException();
+        if (!State.ReadyToReproduce) throw new NotReadyToReproduceException();
+
+        var actionID = GetNextActionID();
+        var action = new ReproduceAction(ID, actionID, dna);
+        lock (PendingActions)
+        {
+            PendingActions.SetReproduceAction(action);
+            InProgressActions.SetReproduceAction(action);
+        }
+    }
+
+    internal int GetNextActionID() => nextActionID++;
+
+    public PendingActions GetThenErasePendingActions()
+    {
+        PendingActions detachedActions;
+        lock (PendingActions)
+        {
+            detachedActions = pendingActions;
+            pendingActions = new PendingActions();
+        }
+        detachedActions.MakeImmutable();
+        return detachedActions;
+    }
+
+    public abstract void InternalMain(bool clearOnly);
+
+    private void InternalTrace(params object[] tracings)
+    {
+        var strings = new string[tracings.Length];
+        for (var i = 0; i < tracings.Length; i++)
+        {
+            strings[i] = tracings[i].ToString()!;
+            strings[i] = strings[i].Substring(0, (strings[i].Length > 8000) ? 8000 : strings[i].Length);
+        }
+        Trace!(this, strings);
+    }
+
+    public void WriteTrace(object item1)
+    {
+        if (Trace != null) InternalTrace(item1);
+    }
+
+    public void WriteTrace(object item1, object item2)
+    {
+        if (Trace != null) InternalTrace(item1, item2);
+    }
+
+    public void WriteTrace(object item1, object item2, object item3)
+    {
+        if (Trace != null) InternalTrace(item1, item2, item3);
+    }
+
+    public void WriteTrace(object item1, object item2, object item3, object item4)
+    {
+        if (Trace != null) InternalTrace(item1, item2, item3, item4);
+    }
+
+    public void InternalOrganismSerialize(MemoryStream m) { }
+
+    public void InternalOrganismDeserialize(MemoryStream m) { }
+}

--- a/src/Terrarium.OrganismBase/Creature/OrganismEventResults.cs
+++ b/src/Terrarium.OrganismBase/Creature/OrganismEventResults.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents all events that will get sent to an animal for a given tick.
+/// </summary>
+public class OrganismEventResults
+{
+    private readonly AttackedEventArgsCollection attackedCollection = new AttackedEventArgsCollection();
+    private AttackCompletedEventArgs? attackCompleted;
+    private BornEventArgs? born;
+    private DefendCompletedEventArgs? defendCompleted;
+    private EatCompletedEventArgs? eatCompleted;
+    private MoveCompletedEventArgs? moveCompleted;
+    private ReproduceCompletedEventArgs? reproduceCompleted;
+    private TeleportedEventArgs? teleported;
+
+    public Boolean IsImmutable { get; private set; }
+
+    public BornEventArgs? Born
+    {
+        get => born;
+        set
+        {
+            if (IsImmutable) throw new ApplicationException("Object is immutable.");
+            born = value;
+        }
+    }
+
+    public ReproduceCompletedEventArgs? ReproduceCompleted
+    {
+        get => reproduceCompleted;
+        set
+        {
+            if (IsImmutable) throw new ApplicationException("Object is immutable.");
+            reproduceCompleted = value;
+        }
+    }
+
+    public TeleportedEventArgs? Teleported
+    {
+        get => teleported;
+        set
+        {
+            if (IsImmutable) throw new ApplicationException("Object is immutable.");
+            teleported = value;
+        }
+    }
+
+    public AttackedEventArgsCollection AttackedEvents => attackedCollection;
+
+    public MoveCompletedEventArgs? MoveCompleted
+    {
+        get => moveCompleted;
+        set
+        {
+            if (IsImmutable) throw new ApplicationException("Object is immutable.");
+            moveCompleted = value;
+        }
+    }
+
+    public AttackCompletedEventArgs? AttackCompleted
+    {
+        get => attackCompleted;
+        set
+        {
+            if (IsImmutable) throw new ApplicationException("Object is immutable.");
+            attackCompleted = value;
+        }
+    }
+
+    public EatCompletedEventArgs? EatCompleted
+    {
+        get => eatCompleted;
+        set
+        {
+            if (IsImmutable) throw new ApplicationException("Object is immutable.");
+            eatCompleted = value;
+        }
+    }
+
+    public DefendCompletedEventArgs? DefendCompleted
+    {
+        get => defendCompleted;
+        set
+        {
+            if (IsImmutable) throw new ApplicationException("Object is immutable.");
+            defendCompleted = value;
+        }
+    }
+
+    public void MakeImmutable()
+    {
+        IsImmutable = true;
+        attackedCollection.MakeImmutable();
+    }
+}

--- a/src/Terrarium.OrganismBase/Creature/PendingActions.cs
+++ b/src/Terrarium.OrganismBase/Creature/PendingActions.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Aggregates the set of pending actions for an organism in one chunk.
+/// </summary>
+public class PendingActions
+{
+    public bool IsImmutable { get; private set; }
+    public DefendAction? DefendAction { get; private set; }
+    public MoveToAction? MoveToAction { get; private set; }
+    public AttackAction? AttackAction { get; private set; }
+    public EatAction? EatAction { get; private set; }
+    public ReproduceAction? ReproduceAction { get; private set; }
+
+    public void MakeImmutable()
+    {
+        IsImmutable = true;
+    }
+
+    public void SetDefendAction(DefendAction? defendAction)
+    {
+        if (IsImmutable) throw new ApplicationException("PendingActions must be mutable to modify actions.");
+        DefendAction = defendAction;
+    }
+
+    public void SetMoveToAction(MoveToAction? moveToAction)
+    {
+        if (IsImmutable) throw new ApplicationException("PendingActions must be mutable to modify actions.");
+        MoveToAction = moveToAction;
+    }
+
+    public void SetAttackAction(AttackAction? attackAction)
+    {
+        if (IsImmutable) throw new ApplicationException("PendingActions must be mutable to modify actions.");
+        AttackAction = attackAction;
+    }
+
+    public void SetEatAction(EatAction? eatAction)
+    {
+        if (IsImmutable) throw new ApplicationException("PendingActions must be mutable to modify actions.");
+        EatAction = eatAction;
+    }
+
+    public void SetReproduceAction(ReproduceAction? reproduceAction)
+    {
+        if (IsImmutable) throw new ApplicationException("PendingActions must be mutable to modify actions.");
+        ReproduceAction = reproduceAction;
+    }
+}

--- a/src/Terrarium.OrganismBase/Engine/EngineSettings.cs
+++ b/src/Terrarium.OrganismBase/Engine/EngineSettings.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Diagnostics;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Contains all constants that affect the game world, creature attributes,
+/// and computed values for the Terrarium. These are the laws of physics
+/// and biology for the Terrarium.
+/// </summary>
+public class EngineSettings
+{
+    public const double AnimalIncubationEnergyMultiplier = 1.5;
+    public const double AnimalIncubationEnergyPerUnitOfRadius =
+        (AnimalMatureSizeProvidedEnergyPerUnitRadius / TicksToIncubate) *
+        AnimalIncubationEnergyMultiplier;
+    public const int AnimalLifeSpanPerUnitMaximumRadius = 50;
+    public const double AnimalMatureSizeProvidedEnergyPerUnitRadius =
+        FoodChunksPerUnitOfRadius * EnergyPerAnimalFoodChunk;
+    public const int AnimalMaxHealingPerTickPerRadius = 2;
+    public const int AnimalReproductionWaitPerUnitRadius = 8;
+    public const double AnimalRequiredEnergyPerUnitOfHealing = .1;
+    public const double AnimalRequiredEnergyPerUnitOfRadiusGrowth = MaxEnergyBasePerUnitRadius * (1 / (double)5);
+    public const double BaseAnimalEnergyPerUnitOfRadius = .001;
+    public const int BaseDefendedDamagePerUnitOfRadius = 50;
+    public const int BaseEatingSpeedPerUnitOfRadius = 1;
+    public const int BaseEyesightRadius = 5;
+    public const int BaseInflictedDamagePerUnitOfRadius = 50;
+    public const int BasePlantEnergyPerUnitOfRadius = 1;
+    public const double CarnivoreAttackDefendMultiplier = 2;
+    public const int CarnivoreLifeSpanMultiplier = 2;
+    public const int DamageToKillPerUnitOfRadius = 190;
+    public const int EnergyPerAnimalFoodChunk = 1;
+    public const int EnergyPerPlantFoodChunk = 1;
+
+    private const double EnergyRequiredToMoveMinimumRequirements =
+        MinimumUnitsToMoveAtMinimumEnergy * MinimumSpeedToMoveAtMinimumEnergy *
+        RequiredEnergyPerUnitOfRadiusSpeedDistance +
+        (MinimumUnitsToMoveAtMinimumEnergy / MinimumSpeedToMoveAtMinimumEnergy) *
+        BaseAnimalEnergyPerUnitOfRadius;
+
+    public const int FoodChunksPerUnitOfRadius = 25;
+    public const int GridCellHeight = 1 << GridHeightPowerOfTwo;
+    public const int GridCellWidth = 1 << GridWidthPowerOfTwo;
+    public const int GridHeightPowerOfTwo = 3;
+    public const int GridWidthPowerOfTwo = 3;
+    public const int InvisibleOddsBase = 0;
+    public const int InvisibleOddsMaximum = 90;
+    public const int MaxAvailableCharacteristicPoints = 100;
+    public const double MaxEnergyBasePerUnitRadius = (int)EnergyRequiredToMoveMinimumRequirements;
+    public const int MaxEnergyFromLightPerTick = 550;
+    public const double MaxEnergyMaximumPerUnitRadius = (int)(EnergyRequiredToMoveMinimumRequirements * 20);
+    public const int MaxGridRadius = (MaxMatureSize / GridCellWidth / 2) + 1;
+    public const int MaximumDefendedDamagePerUnitOfRadius = 25;
+    public const int MaximumEatingSpeedPerUnitOfRadius = 100;
+    public const int MaximumEyesightRadius = 10;
+    public const int MaximumInflictedDamagePerUnitOfRadius = 25;
+    public const int MaxMatureSize = 48;
+    public const int MaxSeedSpreadDistance = 1000;
+
+    private const double MinimumSpeedToMoveAtMinimumEnergy = 5;
+    private const double MinimumUnitsToMoveAtMinimumEnergy = 2000;
+
+    public const int MinMatureSize = 25;
+    public const int NumberOfAnimalsPerTeleporter = 100;
+    public const int OrganismSchedulingBlacklistOvertime = 500000;
+    public const int OrganismSchedulingMaximumOvertime = 50000;
+    public const int PlantFoodChunksPerUnitOfRadius = 50;
+    public const double PlantIncubationEnergyMultiplier = 1.5;
+    public const double PlantIncubationEnergyPerUnitOfRadius =
+        (PlantMatureSizeProvidedEnergyPerUnitRadius / TicksToIncubate) *
+        PlantIncubationEnergyMultiplier;
+    public const int PlantLifeSpanPerUnitMaximumRadius = 150;
+    public const double PlantMatureSizeProvidedEnergyPerUnitRadius =
+        PlantFoodChunksPerUnitOfRadius * EnergyPerPlantFoodChunk;
+    public const int PlantMaxHealingPerTickPerRadius = 1;
+    public const int PlantReproductionWaitPerUnitRadius = 25;
+    public const int PlantRequiredEnergyPerUnitOfHealing = 100;
+    public const double PlantRequiredEnergyPerUnitOfRadiusGrowth = MaxEnergyBasePerUnitRadius * (1 / (double)5);
+    public const double RequiredEnergyPerUnitOfRadiusSpeedDistance = .005;
+    public const int SpeedBase = 5;
+    public const int SpeedMaximum = 100;
+    public const int TicksToIncubate = 10;
+    public const int TimeToRot = 60;
+    public const int ViewPortHeight = 450;
+    public const int ViewPortWidth = 800;
+    public const int MonitorModeHeight = 600;
+    public const int MonitorModeWidth = 800;
+
+    public static void EngineSettingsAsserts()
+    {
+        Debug.Assert(RequiredEnergyPerUnitOfRadiusSpeedDistance > BaseAnimalEnergyPerUnitOfRadius);
+        Debug.Assert(PlantRequiredEnergyPerUnitOfRadiusGrowth <= ((MaxEnergyBasePerUnitRadius / 5) * 1));
+        Debug.Assert(AnimalRequiredEnergyPerUnitOfRadiusGrowth <= ((MaxEnergyBasePerUnitRadius / 5) * 1));
+        Debug.Assert(AnimalIncubationEnergyPerUnitOfRadius <= ((MaxEnergyBasePerUnitRadius / 5) * 1));
+        Debug.Assert(PlantIncubationEnergyPerUnitOfRadius <= ((MaxEnergyBasePerUnitRadius / 5) * 1));
+        Debug.Assert((BasePlantEnergyPerUnitOfRadius * MaxMatureSize) < (MaxEnergyFromLightPerTick / (float)2));
+        Debug.Assert((float)BaseAnimalEnergyPerUnitOfRadius * MaxMatureSize <
+                     EnergyPerPlantFoodChunk * (float)BaseEatingSpeedPerUnitOfRadius);
+        Debug.Assert(((AnimalLifeSpanPerUnitMaximumRadius * MaxMatureSize) / (float)2) >=
+                     3 * ((float)AnimalReproductionWaitPerUnitRadius * MaxMatureSize));
+        Debug.Assert(((PlantLifeSpanPerUnitMaximumRadius * MaxMatureSize) / (float)2) >=
+                     3 * ((float)PlantReproductionWaitPerUnitRadius * MaxMatureSize));
+        Debug.Assert(OrganismSchedulingMaximumOvertime < OrganismSchedulingBlacklistOvertime);
+        Debug.Assert((int)MaxEnergyBasePerUnitRadius > 0);
+    }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/AlreadyFullException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/AlreadyFullException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Organism is already full.</summary>
+public class AlreadyFullException : OrganismException
+{
+    internal AlreadyFullException() : base("Organism is already full.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/AlreadyReproducingException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/AlreadyReproducingException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Can only reproduce when current reproduction is finished.</summary>
+public class AlreadyReproducingException : OrganismException
+{
+    internal AlreadyReproducingException() : base("Can only reproduce when current reproduction is finished.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/GameEngineException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/GameEngineException.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// The base class for all exceptions an organism will receive from the game.
+/// </summary>
+public class GameEngineException : Exception
+{
+    public GameEngineException(string message) : base(message) { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/ImproperFoodException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/ImproperFoodException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Organism tried to eat an improper food: Carnivores must eat meat, and herbivores must eat plants.</summary>
+public class ImproperFoodException : OrganismException
+{
+    internal ImproperFoodException() : base("Organism tried to eat an improper food: Carnivores must eat meat, and herbivores must eat plants.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/IsDeadException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/IsDeadException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>You can only defend against alive animals.</summary>
+public class IsDeadException : OrganismException
+{
+    internal IsDeadException() : base("You can only defend against alive animals.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/NotDeadException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/NotDeadException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>The animal must be dead to eat it.</summary>
+public class NotDeadException : OrganismException
+{
+    internal NotDeadException() : base("The animal must be dead to eat it.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/NotEnoughEnergyException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/NotEnoughEnergyException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Not enough energy to perform this action.</summary>
+public class NotEnoughEnergyException : OrganismException
+{
+    internal NotEnoughEnergyException() : base("Not enough energy to perform this action.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/NotHungryException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/NotHungryException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Organism must be hungry to perform this action.</summary>
+public class NotHungryException : OrganismException
+{
+    internal NotHungryException() : base("Organism must be hungry to perform this action.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/NotMatureException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/NotMatureException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Only mature organisms can reproduce.</summary>
+public class NotMatureException : OrganismException
+{
+    internal NotMatureException() : base("Only mature organisms can reproduce.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/NotReadyToReproduceException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/NotReadyToReproduceException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Not enough time has elapsed since last reproduction.</summary>
+public class NotReadyToReproduceException : OrganismException
+{
+    internal NotReadyToReproduceException() : base("Not enough time has elapsed since last reproduction.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/NotVisibleException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/NotVisibleException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>This organism is not visible.</summary>
+public class NotVisibleException : OrganismException
+{
+    internal NotVisibleException() : base("This organism is not visible.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/NotWithinDistanceException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/NotWithinDistanceException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Too far away to perform action.</summary>
+public class NotWithinDistanceException : OrganismException
+{
+    internal NotWithinDistanceException() : base("Too far away to perform action.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/OrganismException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/OrganismException.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Base class for all exceptions that the game throws to organisms.
+/// </summary>
+public class OrganismException : GameEngineException
+{
+    internal OrganismException(string message) : base(message) { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/OutOfBoundsException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/OutOfBoundsException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>This position is outside the boundaries of the world.</summary>
+public class OutOfBoundsException : OrganismException
+{
+    internal OutOfBoundsException() : base("This position is outside the boundaries of the world.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/SizeOutOfRangeCharacteristicException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/SizeOutOfRangeCharacteristicException.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Size must be within a certain bounds.</summary>
+public class SizeOutOfRangeCharacteristicException : GameEngineException
+{
+    public SizeOutOfRangeCharacteristicException()
+        : base("Size must be <= " + EngineSettings.MaxMatureSize + " and >= " + EngineSettings.MinMatureSize) { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/TooFastException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/TooFastException.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>This organism cannot move this fast.</summary>
+public class TooFastException : OrganismException
+{
+    internal TooFastException() : base("This organism cannot move this fast.") { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/TooManyPointsException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/TooManyPointsException.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>All points supplied for an organism must add up to 100.</summary>
+public class TooManyPointsException : GameEngineException
+{
+    public TooManyPointsException()
+        : base("Total of point-based characteristics must be <= " + EngineSettings.MaxAvailableCharacteristicPoints) { }
+}

--- a/src/Terrarium.OrganismBase/Engine/Exceptions/TooManyPointsOnOneCharacteristicException.cs
+++ b/src/Terrarium.OrganismBase/Engine/Exceptions/TooManyPointsOnOneCharacteristicException.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>Can only apply 100 points to any given characteristic.</summary>
+public class TooManyPointsOnOneCharacteristicException : GameEngineException
+{
+    public TooManyPointsOnOneCharacteristicException()
+        : base("Point-based characteristics must be <= " + EngineSettings.MaxAvailableCharacteristicPoints) { }
+}

--- a/src/Terrarium.OrganismBase/Engine/GenericTypeDescriptor.cs
+++ b/src/Terrarium.OrganismBase/Engine/GenericTypeDescriptor.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.ComponentModel;
+
+namespace OrganismBase;
+
+/// <summary>
+/// A Custom Type Descriptor class used to expand objects into the Property Browser dialog.
+/// </summary>
+[TypeConverter((typeof(ExpandableObjectConverter)))]
+public class GenericTypeDescriptor : ICustomTypeDescriptor
+{
+    private object currentObject;
+    private PropertyDescriptorCollection? propsCollection;
+
+    public GenericTypeDescriptor(object current)
+    {
+        currentObject = current;
+    }
+
+    AttributeCollection ICustomTypeDescriptor.GetAttributes() => new AttributeCollection(null);
+    string? ICustomTypeDescriptor.GetClassName() => null;
+    string? ICustomTypeDescriptor.GetComponentName() => null;
+    TypeConverter? ICustomTypeDescriptor.GetConverter() => null;
+    EventDescriptor? ICustomTypeDescriptor.GetDefaultEvent() => null;
+    PropertyDescriptor? ICustomTypeDescriptor.GetDefaultProperty() => null;
+    object? ICustomTypeDescriptor.GetEditor(Type editorBaseType) => null;
+    EventDescriptorCollection ICustomTypeDescriptor.GetEvents() => EventDescriptorCollection.Empty;
+    EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[]? attributes) => EventDescriptorCollection.Empty;
+
+    PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties() =>
+        ((ICustomTypeDescriptor)this).GetProperties(null);
+
+    PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[]? attributes)
+    {
+        if (propsCollection == null)
+        {
+            propsCollection = TypeDescriptor.GetProperties(currentObject.GetType(), attributes!);
+        }
+        return propsCollection;
+    }
+
+    object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor? pd) => currentObject;
+
+    public void SetObject(object current)
+    {
+        currentObject = current;
+    }
+}

--- a/src/Terrarium.OrganismBase/Engine/Plant.cs
+++ b/src/Terrarium.OrganismBase/Engine/Plant.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.IO;
+
+namespace OrganismBase;
+
+/// <summary>
+/// This is the base class used by any creatures that want to become a Plant.
+/// </summary>
+public abstract class Plant : Organism
+{
+    internal IPlantWorldBoundary World => (IPlantWorldBoundary)OrganismWorldBoundary!;
+
+    public new PlantState State => World.CurrentPlantState;
+
+    public abstract void SerializePlant(MemoryStream m);
+    public abstract void DeserializePlant(MemoryStream m);
+
+    public void InternalPlantSerialize(MemoryStream m) { }
+    public void InternalPlantDeserialize(MemoryStream m) { }
+
+    public override sealed void InternalMain(bool clearOnly)
+    {
+        var events = State.OrganismEvents;
+
+        if (!IsInitialized)
+        {
+            Initialize();
+            IsInitialized = true;
+        }
+
+        if (events != null)
+        {
+            if (events.ReproduceCompleted != null)
+            {
+                if (InProgressActions.ReproduceAction != null &&
+                    events.ReproduceCompleted.ActionID == InProgressActions.ReproduceAction.ActionID)
+                {
+                    InProgressActions.SetReproduceAction(null);
+                }
+            }
+        }
+
+        if (CanReproduce)
+        {
+            BeginReproduction(null);
+        }
+
+        if (clearOnly) InternalTurnsSkipped++;
+        else InternalTurnsSkipped = 0;
+    }
+}

--- a/src/Terrarium.OrganismBase/Enumerations/AnimalSkinFamily.cs
+++ b/src/Terrarium.OrganismBase/Enumerations/AnimalSkinFamily.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Used by the AnimalSkin attribute. Specifies which family of skins to use
+/// when displaying a creature whose custom skin can't be loaded.
+/// </summary>
+public enum AnimalSkinFamily
+{
+    Ant,
+    Beetle,
+    Spider,
+    Inchworm,
+    Scorpion
+}

--- a/src/Terrarium.OrganismBase/Enumerations/AntennaPosition.cs
+++ b/src/Terrarium.OrganismBase/Enumerations/AntennaPosition.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Provides the various positions that the LeftAntenna and RightAntenna may be in.
+/// </summary>
+public enum AntennaPosition
+{
+    Left,
+    Right,
+    Top,
+    Bottom,
+    UpperLeft,
+    UpperRight,
+    BottomLeft,
+    BottomRight,
+    Forward,
+    Backward
+}

--- a/src/Terrarium.OrganismBase/Enumerations/DisplayAction.cs
+++ b/src/Terrarium.OrganismBase/Enumerations/DisplayAction.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Used to determine what the most prominent completed action for the previous tick was.
+/// </summary>
+public enum DisplayAction
+{
+    Attacked = -1,
+    Defended = 7,
+    Dead = 4000,
+    Died = 15,
+    Ate = 23,
+    Moved = 31,
+    NoAction = 32,
+    Teleported = 33,
+    Reproduced = 34
+}

--- a/src/Terrarium.OrganismBase/Enumerations/EnergyState.cs
+++ b/src/Terrarium.OrganismBase/Enumerations/EnergyState.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Contains the different energy levels a creature goes through from Full to Dead.
+/// </summary>
+public enum EnergyState
+{
+    Dead,
+    Deterioration,
+    Hungry,
+    Normal,
+    Full
+}

--- a/src/Terrarium.OrganismBase/Enumerations/PlantSkinFamily.cs
+++ b/src/Terrarium.OrganismBase/Enumerations/PlantSkinFamily.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Used by the PlantSkin attribute. Specifies which family of skins to use
+/// when displaying a creature whose custom skin can't be loaded.
+/// </summary>
+public enum PlantSkinFamily
+{
+    Plant,
+    PlantOne,
+    PlantTwo,
+    PlantThree
+}

--- a/src/Terrarium.OrganismBase/Enumerations/PopulationChangeReason.cs
+++ b/src/Terrarium.OrganismBase/Enumerations/PopulationChangeReason.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Describes the reason for the death of a creature.
+/// </summary>
+public enum PopulationChangeReason
+{
+    NotDead,
+    Initial,
+    Born,
+    OldAge,
+    TeleportedTo,
+    Starved,
+    Sick,
+    TeleportedFrom,
+    Killed,
+    Error,
+    SecurityViolation,
+    Timeout,
+    OrganismBlacklisted
+}

--- a/src/Terrarium.OrganismBase/Enumerations/ReasonForStop.cs
+++ b/src/Terrarium.OrganismBase/Enumerations/ReasonForStop.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Defines the various reasons a creature can be stopped.
+/// </summary>
+public enum ReasonForStop
+{
+    DestinationReached,
+    Blocked
+}

--- a/src/Terrarium.OrganismBase/Helpers/Vector.cs
+++ b/src/Terrarium.OrganismBase/Helpers/Vector.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Drawing;
+
+namespace OrganismBase;
+
+/// <summary>
+/// A classic algebraic vector class for complex movement algorithms.
+/// </summary>
+public class Vector
+{
+    public Vector(double x, double y)
+    {
+        X = x;
+        Y = y;
+    }
+
+    public Vector(Point point)
+    {
+        X = point.X;
+        Y = point.Y;
+    }
+
+    public double X { get; private set; }
+
+    public double Y { get; private set; }
+
+    public Point Point => new Point((int)X, (int)Y);
+
+    public double Magnitude => FastMagnitude;
+
+    public double TrueMagnitude => Math.Sqrt((X * X) + (Y * Y));
+
+    public double Direction
+    {
+        get
+        {
+            var direction = Math.Atan2(Y, X);
+            if (direction < 0)
+            {
+                direction = 2 * Math.PI + direction;
+            }
+            return direction;
+        }
+    }
+
+    internal double FastMagnitude
+    {
+        get
+        {
+            var absX = (X < 0 ? -X : X);
+            var absY = (Y < 0 ? -Y : Y);
+
+            if (absX < absY)
+                return absX + absY - absX / 2;
+
+            return absX + absY - absY / 2;
+        }
+    }
+
+    public Vector Scale(double scalar) => new Vector(X * scalar, Y * scalar);
+
+    public static double ToRadians(double degrees) => (degrees / 360) * 2 * Math.PI;
+
+    public static double ToDegrees(double radians) => (radians / (2 * Math.PI)) * 360;
+
+    public Vector Rotate(double radians)
+    {
+        return new Vector(Math.Cos(radians) * X - Math.Sin(radians) * Y,
+                          Math.Sin(radians) * X + Math.Cos(radians) * Y);
+    }
+
+    public Vector GetUnitVector()
+    {
+        var magnitude = Magnitude;
+        return new Vector(X / magnitude, Y / magnitude);
+    }
+
+    public static Vector Subtract(Point point1, Point point2)
+    {
+        return new Vector(point2.X - point1.X, point2.Y - point1.Y);
+    }
+
+    public static Point Add(Point point, Vector vector)
+    {
+        return new Point(point.X + (int)vector.X, point.Y + (int)vector.Y);
+    }
+
+    public override string ToString()
+    {
+        return string.Format("{{{0}, {1}, mag={2}}}", X, Y, Magnitude);
+    }
+}

--- a/src/Terrarium.OrganismBase/Interfaces/IAnimalSpecies.cs
+++ b/src/Terrarium.OrganismBase/Interfaces/IAnimalSpecies.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Species information properties applicable only to animals.
+/// </summary>
+public interface IAnimalSpecies : ISpecies
+{
+    AnimalSkinFamily SkinFamily { get; }
+    Boolean IsCarnivore { get; }
+    int EatingSpeedPerUnitRadius { get; }
+    int MaximumAttackDamagePerUnitRadius { get; }
+    int MaximumDefendDamagePerUnitRadius { get; }
+    int MaximumSpeed { get; }
+    int InvisibleOdds { get; }
+    int EyesightRadius { get; }
+}

--- a/src/Terrarium.OrganismBase/Interfaces/IAnimalWorldBoundary.cs
+++ b/src/Terrarium.OrganismBase/Interfaces/IAnimalWorldBoundary.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Collections;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents an Animal's view of the world.
+/// </summary>
+public interface IAnimalWorldBoundary : IOrganismWorldBoundary
+{
+    AnimalState CurrentAnimalState { get; }
+    ArrayList Scan();
+    OrganismState? LookFor(OrganismState organismState);
+    OrganismState? LookForNoCamouflage(OrganismState organismState);
+    OrganismState? RefreshState(string organismID);
+}

--- a/src/Terrarium.OrganismBase/Interfaces/IOrganismWorldBoundary.cs
+++ b/src/Terrarium.OrganismBase/Interfaces/IOrganismWorldBoundary.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents the view available to an organism.
+/// </summary>
+public interface IOrganismWorldBoundary
+{
+    OrganismState CurrentOrganismState { get; }
+    string ID { get; }
+    int WorldWidth { get; }
+    int WorldHeight { get; }
+}

--- a/src/Terrarium.OrganismBase/Interfaces/IPlantSpecies.cs
+++ b/src/Terrarium.OrganismBase/Interfaces/IPlantSpecies.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Species information properties applicable only to plants.
+/// </summary>
+public interface IPlantSpecies : ISpecies
+{
+    PlantSkinFamily SkinFamily { get; }
+}

--- a/src/Terrarium.OrganismBase/Interfaces/IPlantWorldBoundary.cs
+++ b/src/Terrarium.OrganismBase/Interfaces/IPlantWorldBoundary.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents a plant's view of the world.
+/// </summary>
+public interface IPlantWorldBoundary : IOrganismWorldBoundary
+{
+    PlantState CurrentPlantState { get; }
+}

--- a/src/Terrarium.OrganismBase/Interfaces/ISpecies.cs
+++ b/src/Terrarium.OrganismBase/Interfaces/ISpecies.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace OrganismBase;
+
+/// <summary>
+/// Holds all species related information common to both plants and animals.
+/// </summary>
+public interface ISpecies
+{
+    int MatureRadius { get; }
+    int ReproductionWait { get; }
+    int LifeSpan { get; }
+    int GrowthWait { get; }
+    int MaximumEnergyPerUnitRadius { get; }
+    string Skin { get; }
+    bool IsSameSpecies(ISpecies species);
+}

--- a/src/Terrarium.OrganismBase/State/AnimalState.cs
+++ b/src/Terrarium.OrganismBase/State/AnimalState.cs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents a creature's state during a certain tick in time.
+/// </summary>
+public sealed class AnimalState : OrganismState
+{
+    private int damage;
+    private AntennaState state = new AntennaState((AntennaState?)null);
+
+    public AnimalState(string id, ISpecies species, int generation, EnergyState initialEnergyState, int initialRadius)
+        : base(id, species, generation, initialEnergyState, initialRadius)
+    {
+    }
+
+    [TypeConverter((typeof(ExpandableObjectConverter)))]
+    public AntennaState Antennas
+    {
+        get
+        {
+            if (IsImmutable) state.MakeImmutable();
+            return state;
+        }
+        set
+        {
+            if (!IsImmutable)
+            {
+                if (value != null) state = value;
+            }
+            else
+            {
+                throw new GameEngineException(
+                    "Antennas can not be set on the State object.  Use the Antennas property on your Creature class instead.");
+            }
+        }
+    }
+
+    public IAnimalSpecies AnimalSpecies => (IAnimalSpecies)Species;
+
+    public int RotTicks { get; private set; }
+
+    public override double PercentInjured
+    {
+        get
+        {
+            Debug.Assert(((damage / (EngineSettings.DamageToKillPerUnitOfRadius * (double)Radius)) * 100) <= 100);
+            return ((damage / (EngineSettings.DamageToKillPerUnitOfRadius * (double)Radius)));
+        }
+    }
+
+    public override DisplayAction PreviousDisplayAction
+    {
+        get
+        {
+            if (!IsAlive && RotTicks == 0) return DisplayAction.Died;
+            return base.PreviousDisplayAction;
+        }
+    }
+
+    public int Damage => damage;
+
+    public override OrganismState CloneMutable()
+    {
+        var newInstance = new AnimalState(ID, AnimalSpecies, Generation, EnergyState, Radius);
+        CopyStateInto(newInstance);
+        return newInstance;
+    }
+
+    protected override void CopyStateInto(OrganismState newInstance)
+    {
+        base.CopyStateInto(newInstance);
+        ((AnimalState)newInstance).damage = damage;
+        ((AnimalState)newInstance).RotTicks = RotTicks;
+        ((AnimalState)newInstance).state = new AntennaState(state);
+    }
+
+    public void AddRotTick()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        Debug.Assert(!IsAlive);
+        RotTicks++;
+    }
+
+    public void CauseDamage(int incrementalDamage)
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        if (incrementalDamage < 0) throw new GameEngineException("Damage must be positive.");
+        if (Damage + incrementalDamage >= EngineSettings.DamageToKillPerUnitOfRadius * Radius)
+        {
+            Kill(PopulationChangeReason.Killed);
+            damage = EngineSettings.DamageToKillPerUnitOfRadius * Radius;
+            return;
+        }
+        damage = damage + incrementalDamage;
+    }
+
+    public override void HealDamage()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        double maxHealing = EngineSettings.AnimalMaxHealingPerTickPerRadius * Radius;
+        Debug.Assert(maxHealing > 0);
+
+        var usableEnergy = StoredEnergy - UpperBoundaryForEnergyState(Species, EnergyState.Hungry, Radius);
+        if (usableEnergy > 0)
+        {
+            var availableHealing = usableEnergy / (EngineSettings.AnimalRequiredEnergyPerUnitOfHealing);
+            if (availableHealing < maxHealing) maxHealing = availableHealing;
+
+            double damageDelta;
+            if (damage - maxHealing < 0)
+            {
+                damageDelta = damage;
+                damage = 0;
+            }
+            else
+            {
+                damageDelta = maxHealing;
+                damage = (int)(damage - maxHealing);
+            }
+
+            BurnEnergy(damageDelta * EngineSettings.AnimalRequiredEnergyPerUnitOfHealing);
+        }
+    }
+
+    public override void IncreaseRadiusTo(int newRadius)
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        var additionalRadius = newRadius - Radius;
+        base.IncreaseRadiusTo(newRadius);
+        currentFoodChunks += additionalRadius * EngineSettings.FoodChunksPerUnitOfRadius;
+    }
+
+    public override OrganismState Grow()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        if (Radius < Species.MatureRadius && GrowthWait == 0)
+        {
+            if (EnergyState >= EnergyState.Normal)
+            {
+                var newState = (AnimalState)CloneMutable();
+                newState.OrganismEvents = OrganismEvents;
+                newState.IncreaseRadiusTo(Radius + 1);
+                newState.BurnEnergy(EngineSettings.AnimalRequiredEnergyPerUnitOfRadiusGrowth);
+                newState.ResetGrowthWait();
+                return newState;
+            }
+        }
+        return this;
+    }
+
+    public double EnergyRequiredToMove(double distance, int speed)
+    {
+        return distance * Radius * speed * EngineSettings.RequiredEnergyPerUnitOfRadiusSpeedDistance;
+    }
+}

--- a/src/Terrarium.OrganismBase/State/MovementVector.cs
+++ b/src/Terrarium.OrganismBase/State/MovementVector.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Drawing;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Used to define a vector along which creatures can move.
+/// Encompasses both destination and speed.
+/// </summary>
+public class MovementVector
+{
+    private readonly int speed;
+    private Point destination;
+
+    public MovementVector(Point destination, int speed)
+    {
+        if (speed < 2)
+        {
+            throw new ApplicationException("Speed must be positive and > 1.");
+        }
+
+        if (!destination.IsEmpty)
+        {
+            this.destination = new Point(destination.X, destination.Y);
+        }
+        else
+        {
+            if (speed != 0)
+            {
+                throw new ApplicationException("Speed must be zero if destination is empty");
+            }
+            this.destination = Point.Empty;
+        }
+
+        this.speed = speed;
+    }
+
+    public Point Destination
+    {
+        get
+        {
+            if (destination.IsEmpty)
+                return Point.Empty;
+            else
+                return new Point(destination.X, destination.Y);
+        }
+    }
+
+    public int Speed => speed;
+
+    public Boolean IsStopped => destination.IsEmpty;
+
+    public override string ToString()
+    {
+        return "MovementVector {" + destination.X + "," + destination.Y + " speed=" + speed + "}";
+    }
+}

--- a/src/Terrarium.OrganismBase/State/OrganismState.cs
+++ b/src/Terrarium.OrganismBase/State/OrganismState.cs
@@ -1,0 +1,370 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Drawing;
+
+namespace OrganismBase;
+
+/// <summary>
+/// All properties of an organism used by the game. Each OrganismState is immutable
+/// and references can be held as long as the organism needs them.
+/// </summary>
+public abstract class OrganismState : IComparable
+{
+    protected int currentFoodChunks;
+    private MoveToAction? currentMoveToAction;
+    private Point currentPosition;
+    private ReproduceAction? currentReproduceAction;
+    private double energy = 1;
+    private OrganismEventResults? events;
+    private bool lockedSizeAndPosition;
+
+    internal OrganismState(string id, ISpecies species, int generation, EnergyState initialEnergyState, int initialRadius)
+    {
+        DeathReason = PopulationChangeReason.NotDead;
+        ID = id;
+        Species = species;
+        Generation = generation;
+        SetStoredEnergyInternal(OrganismState.UpperBoundaryForEnergyState(species, initialEnergyState, initialRadius));
+        Radius = initialRadius;
+        events = new OrganismEventResults();
+    }
+
+    public bool IsImmutable { get; private set; }
+
+    public virtual DisplayAction PreviousDisplayAction
+    {
+        get
+        {
+            if (!IsAlive) return DisplayAction.Dead;
+            if (OrganismEvents != null && OrganismEvents.Teleported != null) return DisplayAction.Teleported;
+            if (OrganismEvents != null && OrganismEvents.AttackCompleted != null) return DisplayAction.Attacked;
+            if (OrganismEvents != null && OrganismEvents.EatCompleted != null) return DisplayAction.Ate;
+            if ((OrganismEvents != null && OrganismEvents.MoveCompleted != null) || IsStopped != true) return DisplayAction.Moved;
+            if (OrganismEvents != null && OrganismEvents.DefendCompleted != null) return DisplayAction.Defended;
+            if ((OrganismEvents != null && OrganismEvents.ReproduceCompleted != null) || IsIncubating) return DisplayAction.Reproduced;
+            return DisplayAction.NoAction;
+        }
+    }
+
+    public object? RenderInfo { get; set; }
+
+    public OrganismEventResults? OrganismEvents
+    {
+        get => events;
+        set
+        {
+            if (IsImmutable) throw new GameEngineException("Object is immutable.");
+            events = value;
+        }
+    }
+
+    [TypeConverter(typeof(ExpandableObjectConverter))]
+    public ISpecies Species { get; private set; }
+
+    public Boolean IsMature => Radius == Species.MatureRadius;
+
+    public PopulationChangeReason DeathReason { get; private set; }
+
+    public int TickAge { get; private set; }
+
+    public int Generation { get; private set; }
+
+    public ReproduceAction? CurrentReproduceAction
+    {
+        get => currentReproduceAction;
+        set
+        {
+            if (IsImmutable) throw new GameEngineException("Object is immutable.");
+            if (!IsAlive) throw new GameEngineException("Dead organisms can't reproduce.");
+            currentReproduceAction = value;
+            if (value == null)
+            {
+                IncubationTicks = 0;
+            }
+            else
+            {
+                Debug.Assert(IncubationTicks == 0, "Organism should not be able to start reproduction while already incubating.");
+            }
+        }
+    }
+
+    public Boolean ReadyToReproduce => ReproductionWait == 0;
+
+    public int ReproductionWait { get; private set; }
+
+    public Boolean IsIncubating => currentReproduceAction != null;
+
+    public int IncubationTicks { get; private set; }
+
+    public int FoodChunks
+    {
+        get => currentFoodChunks;
+        set
+        {
+            if (IsImmutable) throw new GameEngineException("Object is immutable.");
+            if (value <= 0) throw new GameEngineException("If foodchunks <= 0 the organism should be removed from the world.");
+            currentFoodChunks = value;
+        }
+    }
+
+    private void SetStoredEnergyInternal(double newEnergy)
+    {
+        energy = newEnergy;
+    }
+
+    public double StoredEnergy
+    {
+        get => energy;
+        set
+        {
+            if (IsImmutable) throw new GameEngineException("Object is immutable.");
+            if (!IsAlive) throw new GameEngineException("Dead organisms can't change stored energy.");
+            if (value <= 0) { Kill(PopulationChangeReason.Starved); return; }
+            if (value > (double)Radius * Species.MaximumEnergyPerUnitRadius)
+                value = Species.MaximumEnergyPerUnitRadius * (double)Radius;
+            energy = value;
+        }
+    }
+
+    public EnergyState EnergyState
+    {
+        get
+        {
+            var energyBuckets = (Species.MaximumEnergyPerUnitRadius * Radius) / 5;
+            if (energy > energyBuckets * 4) return EnergyState.Full;
+            if (energy > energyBuckets * 2) return EnergyState.Normal;
+            if (energy > energyBuckets * 1) return EnergyState.Hungry;
+            return energy > 0 ? EnergyState.Deterioration : EnergyState.Dead;
+        }
+    }
+
+    public double PercentEnergy
+    {
+        get
+        {
+            Debug.Assert(((energy / (Species.MaximumEnergyPerUnitRadius * Math.Max(1, Radius))) * 100) <= 100);
+            return ((energy / (Species.MaximumEnergyPerUnitRadius * Math.Max(1, Radius))));
+        }
+    }
+
+    public double PercentLifespanRemaining
+    {
+        get
+        {
+            Debug.Assert(1 - ((TickAge / (double)(Species.LifeSpan)) * 100) <= 100);
+            return (1 - (TickAge / (double)(Species.LifeSpan)));
+        }
+    }
+
+    public abstract double PercentInjured { get; }
+
+    public Point Position
+    {
+        get => new Point(currentPosition.X, currentPosition.Y);
+        set
+        {
+            if (IsImmutable) throw new GameEngineException("Object is immutable.");
+            if (lockedSizeAndPosition) throw new GameEngineException("Objects position and size are locked.");
+            if (!IsAlive) throw new GameEngineException("Dead organisms can't move.");
+            currentPosition.X = value.X;
+            currentPosition.Y = value.Y;
+            SetBitmapDirection();
+        }
+    }
+
+    public int GridX => Position.X >> EngineSettings.GridWidthPowerOfTwo;
+    public int GridY => Position.Y >> EngineSettings.GridHeightPowerOfTwo;
+
+    public int CellRadius
+    {
+        get
+        {
+            if (Radius % EngineSettings.GridCellWidth > 0)
+                return (Radius >> EngineSettings.GridWidthPowerOfTwo) + 1;
+            return Radius >> EngineSettings.GridWidthPowerOfTwo;
+        }
+    }
+
+    public int Radius { get; private set; }
+    public string ID { get; private set; }
+
+    public MoveToAction? CurrentMoveToAction
+    {
+        get => currentMoveToAction;
+        set
+        {
+            if (IsImmutable) throw new GameEngineException("Object is immutable.");
+            if (!IsAlive) throw new GameEngineException("Dead organisms can't move.");
+            currentMoveToAction = value;
+            SetBitmapDirection();
+        }
+    }
+
+    public int Speed => currentMoveToAction?.MovementVector.Speed ?? 0;
+
+    public int ActualDirection { get; private set; }
+
+    public Boolean IsStopped => currentMoveToAction == null;
+
+    public Boolean IsAlive => StoredEnergy != 0 && DeathReason == PopulationChangeReason.NotDead && PercentEnergy > 0;
+
+    public int GrowthWait { get; private set; }
+
+    public int CompareTo(Object? other)
+    {
+        if (other is OrganismState state)
+            return currentPosition.Y.CompareTo(state.Position.Y);
+        return 0;
+    }
+
+    public void LockSizeAndPosition()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        lockedSizeAndPosition = true;
+    }
+
+    public void MakeImmutable()
+    {
+        if (events != null) events.MakeImmutable();
+        IsImmutable = true;
+    }
+
+    public abstract OrganismState CloneMutable();
+
+    protected virtual void CopyStateInto(OrganismState newInstance)
+    {
+        newInstance.Radius = Radius;
+        newInstance.currentMoveToAction = currentMoveToAction;
+        newInstance.currentReproduceAction = currentReproduceAction;
+        newInstance.currentPosition = new Point(currentPosition.X, currentPosition.Y);
+        newInstance.energy = energy;
+        newInstance.currentFoodChunks = currentFoodChunks;
+        newInstance.IncubationTicks = IncubationTicks;
+        newInstance.TickAge = TickAge;
+        newInstance.ReproductionWait = ReproductionWait;
+        newInstance.GrowthWait = GrowthWait;
+        newInstance.DeathReason = DeathReason;
+        newInstance.ActualDirection = ActualDirection;
+        newInstance.RenderInfo = RenderInfo;
+    }
+
+    public virtual void AddTickToAge()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        if (!IsAlive) throw new ApplicationException("Dead organisms can't age.");
+        TickAge++;
+        if (GrowthWait != 0) GrowthWait--;
+        if (ReproductionWait != 0) ReproductionWait--;
+        if (TickAge > Species.LifeSpan) Kill(PopulationChangeReason.OldAge);
+    }
+
+    public void ResetReproductionWait()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        ReproductionWait = Species.ReproductionWait;
+    }
+
+    public void AddIncubationTick()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        IncubationTicks++;
+    }
+
+    public void BurnEnergy(double energyValue)
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        if (!IsAlive) throw new GameEngineException("Dead organisms can't change stored energy.");
+        if (StoredEnergy - energyValue <= 0)
+            Kill(PopulationChangeReason.Starved);
+        else
+            StoredEnergy = StoredEnergy - energyValue;
+    }
+
+    public static double UpperBoundaryForEnergyState(ISpecies species, EnergyState energyState, int radius)
+    {
+        var energyBuckets = (species.MaximumEnergyPerUnitRadius * (double)radius) / 5;
+        switch (energyState)
+        {
+            case EnergyState.Dead: return 0;
+            case EnergyState.Deterioration: return energyBuckets * 1;
+            case EnergyState.Hungry: return energyBuckets * 2;
+            case EnergyState.Normal: return energyBuckets * 4;
+            case EnergyState.Full: return species.MaximumEnergyPerUnitRadius * (double)radius;
+            default: throw new ApplicationException("Unknown EnergyState.");
+        }
+    }
+
+    public virtual void IncreaseRadiusTo(int newRadius)
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        if (lockedSizeAndPosition) throw new GameEngineException("Objects position and size are locked.");
+        if (!IsAlive) throw new GameEngineException("Dead organisms can't grow.");
+        if (newRadius <= Radius) throw new GameEngineException("New radius must be bigger than old one.");
+        Radius = newRadius;
+    }
+
+    private void SetBitmapDirection()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        if (CurrentMoveToAction != null)
+        {
+            var direction = Vector.Subtract(CurrentMoveToAction.MovementVector.Destination, currentPosition);
+            var unitVector = direction.GetUnitVector();
+            var angle = Math.Acos(unitVector.X);
+            if (unitVector.Y < 0) angle = 6.2831853 - angle;
+            ActualDirection = (int)((angle / 6.283185) * 360);
+        }
+    }
+
+    public void Kill(PopulationChangeReason reason)
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        currentMoveToAction = null;
+        energy = 0;
+        DeathReason = reason;
+    }
+
+    public abstract OrganismState Grow();
+
+    public void ResetGrowthWait()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        GrowthWait = Species.GrowthWait;
+    }
+
+    public abstract void HealDamage();
+
+    public Boolean IsAdjacentOrOverlapping(OrganismState state2) => IsWithinRect(0, state2);
+
+    public Boolean IsWithinRect(int state1ExtraRadius, OrganismState? state2)
+    {
+        if (null == state2) return false;
+        var state1Radius = CellRadius + state1ExtraRadius;
+        var state2Radius = state2.CellRadius;
+
+        var difference = (GridX - state1Radius) - (state2.GridX - state2Radius);
+        if (difference < 0)
+        {
+            if (-difference > (state1Radius * 2) + 1) return false;
+        }
+        else
+        {
+            if (difference > (state2Radius * 2) + 1) return false;
+        }
+
+        difference = (GridY - state1Radius) - (state2.GridY - state2Radius);
+        if (difference < 0)
+        {
+            if (-difference > (state1Radius * 2) + 1) return false;
+        }
+        else
+        {
+            if (difference > (state2Radius * 2) + 1) return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Terrarium.OrganismBase/State/PlantState.cs
+++ b/src/Terrarium.OrganismBase/State/PlantState.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Diagnostics;
+
+namespace OrganismBase;
+
+/// <summary>
+/// Represents a plant's state during a certain tick in time.
+/// </summary>
+public sealed class PlantState : OrganismState
+{
+    private const double heightToRadiusRatio = 1;
+    private const int optimalLightPercentage = 100;
+
+    public PlantState(string id, ISpecies species, int generation, EnergyState initialEnergyState, int initialRadius)
+        : base(id, species, generation, initialEnergyState, initialRadius)
+    {
+    }
+
+    public int Height { get; private set; }
+
+    public int CurrentMaxFoodChunks => Radius * EngineSettings.PlantFoodChunksPerUnitOfRadius;
+
+    public override double PercentInjured
+    {
+        get
+        {
+            Debug.Assert(1 - ((FoodChunks / (double)CurrentMaxFoodChunks) * 100) <= 100);
+            return 1 - (FoodChunks / (double)CurrentMaxFoodChunks);
+        }
+    }
+
+    public override OrganismState CloneMutable()
+    {
+        var newInstance = new PlantState(ID, Species, Generation, EnergyState, Radius);
+        CopyStateInto(newInstance);
+        return newInstance;
+    }
+
+    protected override void CopyStateInto(OrganismState newInstance)
+    {
+        base.CopyStateInto(newInstance);
+        ((PlantState)newInstance).Height = Height;
+    }
+
+    public void GiveEnergy(int availableLightPercentage)
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        var percentageFromOptimal = availableLightPercentage - optimalLightPercentage;
+        if (percentageFromOptimal < 0) percentageFromOptimal = -percentageFromOptimal;
+        Debug.Assert(percentageFromOptimal <= 100);
+
+        var energyGained = (int)((1 - (percentageFromOptimal / (double)100)) * EngineSettings.MaxEnergyFromLightPerTick);
+        StoredEnergy = StoredEnergy + energyGained;
+    }
+
+    public override void IncreaseRadiusTo(int newRadius)
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        var newHeight = (int)(newRadius * heightToRadiusRatio);
+        var additionalRadius = newRadius - Radius;
+        base.IncreaseRadiusTo(newRadius);
+        Height = newHeight;
+        currentFoodChunks += additionalRadius * EngineSettings.PlantFoodChunksPerUnitOfRadius;
+    }
+
+    public override OrganismState Grow()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        if (Radius < Species.MatureRadius)
+        {
+            if (EnergyState >= EnergyState.Normal && GrowthWait == 0)
+            {
+                var newState = (PlantState)CloneMutable();
+                newState.OrganismEvents = OrganismEvents;
+                newState.IncreaseRadiusTo(Radius + 1);
+                newState.BurnEnergy(EngineSettings.PlantRequiredEnergyPerUnitOfRadiusGrowth);
+                newState.ResetGrowthWait();
+                return newState;
+            }
+        }
+        return this;
+    }
+
+    public override void HealDamage()
+    {
+        if (IsImmutable) throw new GameEngineException("Object is immutable.");
+        var maxHealingChunks = EngineSettings.PlantMaxHealingPerTickPerRadius * Radius;
+
+        var usableEnergy = StoredEnergy - UpperBoundaryForEnergyState(Species, EnergyState.Deterioration, Radius);
+        if (usableEnergy <= 0) return;
+
+        var availableHealingChunks = (int)(usableEnergy / (EngineSettings.PlantRequiredEnergyPerUnitOfHealing));
+        if (availableHealingChunks < maxHealingChunks)
+            maxHealingChunks = availableHealingChunks;
+
+        int foodChunkDelta;
+        if (CurrentMaxFoodChunks - FoodChunks < maxHealingChunks)
+        {
+            foodChunkDelta = CurrentMaxFoodChunks - FoodChunks;
+            currentFoodChunks = CurrentMaxFoodChunks;
+        }
+        else
+        {
+            foodChunkDelta = maxHealingChunks;
+            currentFoodChunks += foodChunkDelta;
+        }
+
+        BurnEnergy(foodChunkDelta * (double)EngineSettings.PlantRequiredEnergyPerUnitOfHealing);
+    }
+}

--- a/src/Terrarium.OrganismBase/Terrarium.OrganismBase.csproj
+++ b/src/Terrarium.OrganismBase/Terrarium.OrganismBase.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>OrganismBase</RootNamespace>
+    <AssemblyName>OrganismBase</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Closes #3

Ports the OrganismBase creature SDK from .NET Framework 3.5 to .NET 10.

Key changes:
- BinaryFormatter -> System.Text.Json (removed [Serializable] + BinaryFormatter patterns)
- Hashtable/ArrayList -> generic collections (List<T>, Dictionary<K,V>)
- ReadOnlyCollectionBase -> List<T> wrapper
- File-scoped namespaces
- Nullable reference types enabled
- CAS attributes removed
- [Serializable] removed from all types (not needed in modern .NET)
- Public API surface preserved for creature compatibility

91 files ported, 0 warnings, 0 errors.