### PR TITLE
Create Terrarium.Services client-side service layer

### DIFF
--- a/.ai-team/agents/mike/history.md
+++ b/.ai-team/agents/mike/history.md
@@ -59,3 +59,31 @@
 📌 Team update (2026-02-11): CSS token naming: --glass-{category}-{element}-{modifier}, BEM for components — decided by Jesse
 📌 Team update (2025-07-16): Solution uses classic .sln format (not .slnx); CS1591 suppressed during initial port — decided by Heisenberg
 📌 Team update (2025-07-15): CSS tokens use `--glass-{category}-{element}-{modifier}` naming; BEM classes; `glass-theme.css` is single source of truth — decided by Jesse
+
+### 2025-07-16 — Terrarium.Services Client-Side Service Layer (#14)
+
+Created `src/Terrarium.Services/` — a clean HttpClient-based replacement for the 8 legacy ASMX Web Reference proxies in `Client/Services/Web References/`.
+
+**What was built:**
+- 6 interfaces: IMessagingService, IPeerDiscoveryService, ISpeciesService, IPopulationService, IReportingService, IChartService
+- 6 HttpClient-based implementations in `Clients/`
+- 10 model types in `Models/` (BugReport, UsageData, SpeciesInfo, PeerInfo, PopulationData, PopulationEntry, VersionCheckResult + 3 enums)
+- `ServiceCollectionExtensions` with DI registration and Aspire service discovery support
+- Added to `Terrarium.sln`, builds clean
+
+**Legacy proxy → new service mapping:**
+- Messaging → IMessagingService (aligned with Gus's `/api/messaging/*` endpoints)
+- Discovery → IPeerDiscoveryService
+- Species → ISpeciesService
+- Reporting → IPopulationService
+- BugReporting + Watson + Usage → IReportingService (consolidated)
+- Charts → IChartService
+
+**Key decisions:**
+- Interface-first design for testability and DI
+- No ServiceDefaults dependency — pure class library, depends only on `Microsoft.Extensions.Http` and `Microsoft.Extensions.Options`
+- System.Text.Json serialization, no DataSet, no SOAP
+- CancellationToken on all async methods
+- Aspire service discovery via `AddTerrariumServices(serviceName)` overload
+
+PR #109, branch `squad/14-services-layer`.

--- a/.ai-team/decisions/inbox/mike-services-layer.md
+++ b/.ai-team/decisions/inbox/mike-services-layer.md
@@ -1,0 +1,17 @@
+### Terrarium.Services is a pure class library — no ServiceDefaults dependency
+**By:** Mike (Networking / Engine Dev)
+**Status:** Decided
+**Issue:** #14
+**PR:** #109
+
+**What:** `Terrarium.Services` depends only on `Microsoft.Extensions.Http` and `Microsoft.Extensions.Options`. It does NOT reference `Terrarium.ServiceDefaults`. This keeps it usable by any consumer (Game client, tests, CLI tools) without pulling in ASP.NET Core or OpenTelemetry.
+
+Consumers that want Aspire integration (resilience, service discovery) configure it at the DI level:
+```csharp
+services.AddTerrariumServices("terrarium-server"); // Aspire service discovery
+services.AddTerrariumServices(new Uri("https://api.terrarium.dev")); // explicit URI
+```
+
+**Impact:** Gus (Server Dev) — the client-side contracts are defined. Server endpoints should return JSON matching the models in `Terrarium.Services.Models`. Hank (QA) — all services are interface-based, straightforward to mock for testing.
+
+**Why:** Interface-first with minimal dependencies is the right call. The legacy proxies were auto-generated ASMX stubs tightly coupled to SOAP. The new layer is clean, testable, and works with or without Aspire.

--- a/src/Terrarium.Services/Clients/ChartServiceClient.cs
+++ b/src/Terrarium.Services/Clients/ChartServiceClient.cs
@@ -1,0 +1,48 @@
+using System.Net.Http.Json;
+using Terrarium.Services.Interfaces;
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Clients;
+
+public sealed class ChartServiceClient(HttpClient httpClient) : IChartService
+{
+    public async Task<IReadOnlyList<SpeciesInfo>> GetSpeciesListAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<List<SpeciesInfo>>("charts/species", cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<string> ChartPopulationAsync(DateTime start, DateTime end, IReadOnlyList<string> speciesNames,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("charts/population",
+            new { start, end, speciesNames }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+    }
+
+    public async Task<string> ChartVitalsAsync(DateTime start, DateTime end, string species,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetAsync(
+            $"charts/vitals?start={start:O}&end={end:O}&species={Uri.EscapeDataString(species)}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+    }
+
+    public async Task<IReadOnlyList<SpeciesInfo>> GrabLatestSpeciesDataAsync(string species,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<List<SpeciesInfo>>(
+            $"charts/species/{Uri.EscapeDataString(species)}/latest", cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<IReadOnlyList<SpeciesInfo>> GetTopAnimalsAsync(string version, OrganismType type, int count,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<List<SpeciesInfo>>(
+            $"charts/top?version={Uri.EscapeDataString(version)}&type={type}&count={count}", cancellationToken);
+        return result ?? [];
+    }
+}

--- a/src/Terrarium.Services/Clients/MessagingServiceClient.cs
+++ b/src/Terrarium.Services/Clients/MessagingServiceClient.cs
@@ -1,0 +1,28 @@
+using System.Net.Http.Json;
+using Terrarium.Services.Interfaces;
+
+namespace Terrarium.Services.Clients;
+
+public sealed class MessagingServiceClient(HttpClient httpClient) : IMessagingService
+{
+    public async Task<string> GetWelcomeMessageAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetAsync("messaging/welcome", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+    }
+
+    public async Task<string> GetMessageOfTheDayAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetAsync("messaging/motd", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+    }
+
+    public async Task<string> GetLatestVersionAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetAsync("messaging/version", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+    }
+}

--- a/src/Terrarium.Services/Clients/PeerDiscoveryServiceClient.cs
+++ b/src/Terrarium.Services/Clients/PeerDiscoveryServiceClient.cs
@@ -1,0 +1,45 @@
+using System.Net.Http.Json;
+using Terrarium.Services.Interfaces;
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Clients;
+
+public sealed class PeerDiscoveryServiceClient(HttpClient httpClient) : IPeerDiscoveryService
+{
+    public async Task<bool> RegisterUserAsync(string email, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("discovery/register-user", new { email }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<bool>(cancellationToken);
+    }
+
+    public async Task<int> GetNumPeersAsync(string version, string channel, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetAsync($"discovery/peers/count?version={Uri.EscapeDataString(version)}&channel={Uri.EscapeDataString(channel)}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<int>(cancellationToken);
+    }
+
+    public async Task<string> ValidatePeerAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetAsync("discovery/validate", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+    }
+
+    public async Task<PeerRegistrationResult> RegisterPeerAsync(string version, string channel, Guid peerGuid, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("discovery/register", new { version, channel, peerGuid }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<PeerRegistrationResult>(cancellationToken)
+            ?? new PeerRegistrationResult { Status = RegisterPeerResult.Failure };
+    }
+
+    public async Task<VersionCheckResult> IsVersionDisabledAsync(string version, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetAsync($"discovery/version-check?version={Uri.EscapeDataString(version)}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<VersionCheckResult>(cancellationToken)
+            ?? new VersionCheckResult { IsDisabled = true, ErrorMessage = "Failed to check version status" };
+    }
+}

--- a/src/Terrarium.Services/Clients/PopulationServiceClient.cs
+++ b/src/Terrarium.Services/Clients/PopulationServiceClient.cs
@@ -1,0 +1,15 @@
+using System.Net.Http.Json;
+using Terrarium.Services.Interfaces;
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Clients;
+
+public sealed class PopulationServiceClient(HttpClient httpClient) : IPopulationService
+{
+    public async Task<int> ReportPopulationAsync(PopulationData data, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("population/report", data, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<int>(cancellationToken);
+    }
+}

--- a/src/Terrarium.Services/Clients/ReportingServiceClient.cs
+++ b/src/Terrarium.Services/Clients/ReportingServiceClient.cs
@@ -1,0 +1,26 @@
+using System.Net.Http.Json;
+using Terrarium.Services.Interfaces;
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Clients;
+
+public sealed class ReportingServiceClient(HttpClient httpClient) : IReportingService
+{
+    public async Task ReportBugAsync(BugReport report, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("reporting/bugs", report, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task ReportErrorAsync(string errorData, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("reporting/errors", new { errorData }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task ReportUsageAsync(UsageData data, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("reporting/usage", data, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/Terrarium.Services/Clients/SpeciesServiceClient.cs
+++ b/src/Terrarium.Services/Clients/SpeciesServiceClient.cs
@@ -1,0 +1,69 @@
+using System.Net.Http.Json;
+using Terrarium.Services.Interfaces;
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Clients;
+
+public sealed class SpeciesServiceClient(HttpClient httpClient) : ISpeciesService
+{
+    public async Task<SpeciesServiceStatus> AddAsync(string name, string version, string type, string author,
+        string email, string assemblyFullName, byte[] assemblyCode,
+        CancellationToken cancellationToken = default)
+    {
+        var payload = new
+        {
+            name,
+            version,
+            type,
+            author,
+            email,
+            assemblyFullName,
+            assemblyCode = Convert.ToBase64String(assemblyCode)
+        };
+
+        var response = await httpClient.PostAsJsonAsync("species", payload, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<SpeciesServiceStatus>(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<SpeciesInfo>> GetExtinctSpeciesAsync(string version, string filter,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<List<SpeciesInfo>>(
+            $"species/extinct?version={Uri.EscapeDataString(version)}&filter={Uri.EscapeDataString(filter)}", cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<IReadOnlyList<SpeciesInfo>> GetAllSpeciesAsync(string version, string filter,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<List<SpeciesInfo>>(
+            $"species?version={Uri.EscapeDataString(version)}&filter={Uri.EscapeDataString(filter)}", cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<byte[]> GetSpeciesAssemblyAsync(string name, string version,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.GetAsync(
+            $"species/{Uri.EscapeDataString(name)}/assembly?version={Uri.EscapeDataString(version)}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsByteArrayAsync(cancellationToken);
+    }
+
+    public async Task<byte[]> ReintroduceSpeciesAsync(string name, string version, Guid peerGuid,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync(
+            $"species/{Uri.EscapeDataString(name)}/reintroduce",
+            new { version, peerGuid }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadAsByteArrayAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<string>> GetBlacklistedSpeciesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<List<string>>("species/blacklisted", cancellationToken);
+        return result ?? [];
+    }
+}

--- a/src/Terrarium.Services/Interfaces/IChartService.cs
+++ b/src/Terrarium.Services/Interfaces/IChartService.cs
@@ -1,0 +1,20 @@
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Interfaces;
+
+public interface IChartService
+{
+    Task<IReadOnlyList<SpeciesInfo>> GetSpeciesListAsync(CancellationToken cancellationToken = default);
+
+    Task<string> ChartPopulationAsync(DateTime start, DateTime end, IReadOnlyList<string> speciesNames,
+        CancellationToken cancellationToken = default);
+
+    Task<string> ChartVitalsAsync(DateTime start, DateTime end, string species,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SpeciesInfo>> GrabLatestSpeciesDataAsync(string species,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SpeciesInfo>> GetTopAnimalsAsync(string version, OrganismType type, int count,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Terrarium.Services/Interfaces/IMessagingService.cs
+++ b/src/Terrarium.Services/Interfaces/IMessagingService.cs
@@ -1,0 +1,8 @@
+namespace Terrarium.Services.Interfaces;
+
+public interface IMessagingService
+{
+    Task<string> GetWelcomeMessageAsync(CancellationToken cancellationToken = default);
+    Task<string> GetMessageOfTheDayAsync(CancellationToken cancellationToken = default);
+    Task<string> GetLatestVersionAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Terrarium.Services/Interfaces/IPeerDiscoveryService.cs
+++ b/src/Terrarium.Services/Interfaces/IPeerDiscoveryService.cs
@@ -1,0 +1,12 @@
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Interfaces;
+
+public interface IPeerDiscoveryService
+{
+    Task<bool> RegisterUserAsync(string email, CancellationToken cancellationToken = default);
+    Task<int> GetNumPeersAsync(string version, string channel, CancellationToken cancellationToken = default);
+    Task<string> ValidatePeerAsync(CancellationToken cancellationToken = default);
+    Task<PeerRegistrationResult> RegisterPeerAsync(string version, string channel, Guid peerGuid, CancellationToken cancellationToken = default);
+    Task<VersionCheckResult> IsVersionDisabledAsync(string version, CancellationToken cancellationToken = default);
+}

--- a/src/Terrarium.Services/Interfaces/IPopulationService.cs
+++ b/src/Terrarium.Services/Interfaces/IPopulationService.cs
@@ -1,0 +1,8 @@
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Interfaces;
+
+public interface IPopulationService
+{
+    Task<int> ReportPopulationAsync(PopulationData data, CancellationToken cancellationToken = default);
+}

--- a/src/Terrarium.Services/Interfaces/IReportingService.cs
+++ b/src/Terrarium.Services/Interfaces/IReportingService.cs
@@ -1,0 +1,10 @@
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Interfaces;
+
+public interface IReportingService
+{
+    Task ReportBugAsync(BugReport report, CancellationToken cancellationToken = default);
+    Task ReportErrorAsync(string errorData, CancellationToken cancellationToken = default);
+    Task ReportUsageAsync(UsageData data, CancellationToken cancellationToken = default);
+}

--- a/src/Terrarium.Services/Interfaces/ISpeciesService.cs
+++ b/src/Terrarium.Services/Interfaces/ISpeciesService.cs
@@ -1,0 +1,24 @@
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Interfaces;
+
+public interface ISpeciesService
+{
+    Task<SpeciesServiceStatus> AddAsync(string name, string version, string type, string author,
+        string email, string assemblyFullName, byte[] assemblyCode,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SpeciesInfo>> GetExtinctSpeciesAsync(string version, string filter,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SpeciesInfo>> GetAllSpeciesAsync(string version, string filter,
+        CancellationToken cancellationToken = default);
+
+    Task<byte[]> GetSpeciesAssemblyAsync(string name, string version,
+        CancellationToken cancellationToken = default);
+
+    Task<byte[]> ReintroduceSpeciesAsync(string name, string version, Guid peerGuid,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<string>> GetBlacklistedSpeciesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Terrarium.Services/Models/BugReport.cs
+++ b/src/Terrarium.Services/Models/BugReport.cs
@@ -1,0 +1,10 @@
+namespace Terrarium.Services.Models;
+
+public sealed class BugReport
+{
+    public required string Title { get; init; }
+    public required string Description { get; init; }
+    public string? Path { get; init; }
+    public string? Alias { get; init; }
+    public string? Version { get; init; }
+}

--- a/src/Terrarium.Services/Models/OrganismType.cs
+++ b/src/Terrarium.Services/Models/OrganismType.cs
@@ -1,0 +1,8 @@
+namespace Terrarium.Services.Models;
+
+public enum OrganismType
+{
+    Carnivore,
+    Herbivore,
+    Plant
+}

--- a/src/Terrarium.Services/Models/PeerInfo.cs
+++ b/src/Terrarium.Services/Models/PeerInfo.cs
@@ -1,0 +1,9 @@
+namespace Terrarium.Services.Models;
+
+public sealed class PeerInfo
+{
+    public required string IPAddress { get; init; }
+    public required string Version { get; init; }
+    public string? Channel { get; init; }
+    public DateTime? LastContact { get; init; }
+}

--- a/src/Terrarium.Services/Models/PeerRegistrationResult.cs
+++ b/src/Terrarium.Services/Models/PeerRegistrationResult.cs
@@ -1,0 +1,8 @@
+namespace Terrarium.Services.Models;
+
+public sealed class PeerRegistrationResult
+{
+    public required RegisterPeerResult Status { get; init; }
+    public int PeerCount { get; init; }
+    public IReadOnlyList<PeerInfo> Peers { get; init; } = [];
+}

--- a/src/Terrarium.Services/Models/PopulationData.cs
+++ b/src/Terrarium.Services/Models/PopulationData.cs
@@ -1,0 +1,15 @@
+namespace Terrarium.Services.Models;
+
+public sealed class PopulationData
+{
+    public required Guid PeerGuid { get; init; }
+    public required int CurrentTick { get; init; }
+    public required IReadOnlyList<PopulationEntry> Entries { get; init; }
+}
+
+public sealed class PopulationEntry
+{
+    public required string SpeciesName { get; init; }
+    public required int Population { get; init; }
+    public required string Version { get; init; }
+}

--- a/src/Terrarium.Services/Models/RegisterPeerResult.cs
+++ b/src/Terrarium.Services/Models/RegisterPeerResult.cs
@@ -1,0 +1,8 @@
+namespace Terrarium.Services.Models;
+
+public enum RegisterPeerResult
+{
+    Success,
+    Failure,
+    GlobalFailure
+}

--- a/src/Terrarium.Services/Models/SpeciesInfo.cs
+++ b/src/Terrarium.Services/Models/SpeciesInfo.cs
@@ -1,0 +1,16 @@
+namespace Terrarium.Services.Models;
+
+public sealed class SpeciesInfo
+{
+    public required string Name { get; init; }
+    public required string Author { get; init; }
+    public required string AuthorEmail { get; init; }
+    public required OrganismType Type { get; init; }
+    public required string Version { get; init; }
+    public required string AssemblyFullName { get; init; }
+    public bool IsExtinct { get; init; }
+    public bool IsBlacklisted { get; init; }
+    public int Population { get; init; }
+    public DateTime? DateAdded { get; init; }
+    public DateTime? LastReintroduction { get; init; }
+}

--- a/src/Terrarium.Services/Models/SpeciesServiceStatus.cs
+++ b/src/Terrarium.Services/Models/SpeciesServiceStatus.cs
@@ -1,0 +1,14 @@
+namespace Terrarium.Services.Models;
+
+public enum SpeciesServiceStatus
+{
+    Success,
+    AlreadyExists,
+    ServerDown,
+    VersionIncompatible,
+    FiveMinuteThrottle,
+    TwentyFourHourThrottle,
+    PoliCheckSpeciesNameFailure,
+    PoliCheckAuthorNameFailure,
+    PoliCheckEmailFailure
+}

--- a/src/Terrarium.Services/Models/UsageData.cs
+++ b/src/Terrarium.Services/Models/UsageData.cs
@@ -1,0 +1,23 @@
+namespace Terrarium.Services.Models;
+
+public sealed class UsageData
+{
+    public string? Alias { get; init; }
+    public string? Domain { get; init; }
+    public string? GameVersion { get; init; }
+    public string? PeerChannel { get; init; }
+    public int PeerCount { get; init; }
+    public int AnimalCount { get; init; }
+    public int MaxAnimalCount { get; init; }
+    public int WorldWidth { get; init; }
+    public int WorldHeight { get; init; }
+    public string? MachineName { get; init; }
+    public string? OSVersion { get; init; }
+    public int ProcessorCount { get; init; }
+    public string? ClrVersion { get; init; }
+    public int WorkingSet { get; init; }
+    public int MaxWorkingSet { get; init; }
+    public int MinWorkingSet { get; init; }
+    public int ProcessorTimeInSeconds { get; init; }
+    public DateTime ProcessStartTime { get; init; }
+}

--- a/src/Terrarium.Services/Models/VersionCheckResult.cs
+++ b/src/Terrarium.Services/Models/VersionCheckResult.cs
@@ -1,0 +1,7 @@
+namespace Terrarium.Services.Models;
+
+public sealed class VersionCheckResult
+{
+    public required bool IsDisabled { get; init; }
+    public string? ErrorMessage { get; init; }
+}

--- a/src/Terrarium.Services/ServiceCollectionExtensions.cs
+++ b/src/Terrarium.Services/ServiceCollectionExtensions.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.DependencyInjection;
+using Terrarium.Services.Clients;
+using Terrarium.Services.Interfaces;
+
+namespace Terrarium.Services;
+
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers all Terrarium service clients with the DI container.
+    /// Configures named HttpClient instances for each service.
+    /// </summary>
+    public static IServiceCollection AddTerrariumServices(this IServiceCollection services, Uri baseAddress)
+    {
+        services.AddHttpClient<IMessagingService, MessagingServiceClient>(client =>
+            client.BaseAddress = new Uri(baseAddress, "api/"));
+
+        services.AddHttpClient<IPeerDiscoveryService, PeerDiscoveryServiceClient>(client =>
+            client.BaseAddress = new Uri(baseAddress, "api/"));
+
+        services.AddHttpClient<ISpeciesService, SpeciesServiceClient>(client =>
+            client.BaseAddress = new Uri(baseAddress, "api/"));
+
+        services.AddHttpClient<IPopulationService, PopulationServiceClient>(client =>
+            client.BaseAddress = new Uri(baseAddress, "api/"));
+
+        services.AddHttpClient<IReportingService, ReportingServiceClient>(client =>
+            client.BaseAddress = new Uri(baseAddress, "api/"));
+
+        services.AddHttpClient<IChartService, ChartServiceClient>(client =>
+            client.BaseAddress = new Uri(baseAddress, "api/"));
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers all Terrarium service clients using Aspire service discovery.
+    /// Use this overload when the server is registered in Aspire as a named resource.
+    /// </summary>
+    public static IServiceCollection AddTerrariumServices(this IServiceCollection services, string serviceName)
+    {
+        return services.AddTerrariumServices(new Uri($"https+http://{serviceName}"));
+    }
+}

--- a/src/Terrarium.Services/Terrarium.Services.csproj
+++ b/src/Terrarium.Services/Terrarium.Services.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Closes #14

Replaces 8 legacy ASMX Web Reference proxies with clean HttpClient-based service clients.

**Structure:**
- Models/ — DTOs and enums (BugReport, UsageData, SpeciesInfo, PeerInfo, PopulationData, OrganismType, RegisterPeerResult, SpeciesServiceStatus, VersionCheckResult)
- Interfaces/ — IMessagingService, IPeerDiscoveryService, ISpeciesService, IPopulationService, IReportingService, IChartService
- Clients/ — HttpClient implementations targeting Minimal API endpoints
- ServiceCollectionExtensions — DI registration with Aspire service discovery support

**Key decisions:** Interface-first for testability, System.Text.Json (no DataSet/SOAP), CancellationToken everywhere, pure class library (no ServiceDefaults dependency).