### PR TITLE
Port PeerDiscovery and Watson endpoints

### DIFF
--- a/.ai-team/agents/mike/history.md
+++ b/.ai-team/agents/mike/history.md
@@ -87,3 +87,32 @@ Created `src/Terrarium.Services/` — a clean HttpClient-based replacement for t
 - Aspire service discovery via `AddTerrariumServices(serviceName)` overload
 
 PR #109, branch `squad/14-services-layer`.
+
+### 2025-07-16 — Terrarium.Net SignalR Hub Layer (#16)
+
+Created `src/Terrarium.Net/` — the SignalR contract layer replacing the legacy custom HttpWebListener and TCP peer-to-peer networking stack.
+
+**What was built:**
+- `ITerrariumClient` — server-to-client interface: `ReceiveEcosystemTick`, `ReceiveWorldStateUpdate`, `ReceiveCreatureTeleport`, `ReceivePeerAnnounce`
+- `ITerrariumHub` — client-to-server interface: `JoinEcosystem`, `LeaveEcosystem`, `TeleportCreature`, `AnnouncePeer`, `RequestWorldState`
+- `TerrariumHub : Hub<ITerrariumClient>` — thin relay implementation using SignalR groups per ecosystem
+- 4 message types in `Messages/`:
+  - `WorldStateUpdate` — tick-indexed world snapshot
+  - `CreatureTeleport` — replaces legacy 4-step HTTP teleport protocol (version check → assembly check → assembly transfer → state transfer) with a single message carrying optional assembly payload
+  - `PeerAnnounce` — replaces SOAP-based PeerDiscoveryService polling with push-based join/leave/heartbeat
+  - `EcosystemTick` — lightweight tick clock signal
+
+**Legacy → new mapping:**
+- `HttpWebListener` (custom TCP, port 50000) → SignalR WebSocket transport
+- `NetworkEngine.Teleport()` 4-step HTTP → `CreatureTeleport` single message
+- `PeerDiscoveryService` SOAP polling → `PeerAnnounce` + SignalR groups
+- `PeerManager` good/bad peer lists → Orleans `PeerGrain` (Sprint 7)
+
+**Key decisions:**
+- Uses `FrameworkReference Microsoft.AspNetCore.App` — SignalR is in-box for net10.0, no NuGet package needed
+- Hub is intentionally thin — all TODO comments mark where Orleans grain calls will be added in Sprint 7
+- `CreatureTeleport.AssemblyPayload` is optional Base64 — only sent when target peer lacks the assembly
+- `PeerAction` enum (Join/Leave/Heartbeat) replaces the lease-timeout pattern from `PeerManager`
+- No dependency on other Terrarium projects — pure contract library
+
+PR #113, branch `squad/16-networking-layer`.

--- a/.ai-team/decisions/inbox/mike-signalr-hub-contract-layer.md
+++ b/.ai-team/decisions/inbox/mike-signalr-hub-contract-layer.md
@@ -1,0 +1,34 @@
+# Decision: SignalR Hub as Pure Contract Layer
+
+**By:** Mike (Networking / Engine Dev)
+**Date:** 2025-07-16
+**Status:** Implemented (PR #113)
+**Issue:** #16
+
+## What
+
+`Terrarium.Net` is a contract-only library. It defines interfaces (`ITerrariumHub`, `ITerrariumClient`), message types, and a thin `TerrariumHub` implementation. No business logic.
+
+## Key Technical Decisions
+
+1. **FrameworkReference, not NuGet** — `Microsoft.AspNetCore.App` FrameworkReference gives us SignalR for free on net10.0. No version pinning needed.
+
+2. **Single-message teleport** — The legacy 4-step HTTP teleport protocol (version check → assembly check → assembly transfer → state transfer) is collapsed into a single `CreatureTeleport` message. The optional `AssemblyPayload` field carries base64-encoded assembly bytes only when the target peer doesn't have the species assembly. Assembly presence tracking will be handled by `PeerGrain` in Sprint 7.
+
+3. **SignalR groups = ecosystems** — Each ecosystem ID maps to a SignalR group. `JoinEcosystem`/`LeaveEcosystem` manage group membership. This replaces the SOAP-based peer discovery polling loop.
+
+4. **No Terrarium project dependencies** — `Terrarium.Net` depends only on the ASP.NET Core shared framework. Message types use `string` for state payloads (JSON) rather than referencing `Terrarium.OrganismBase` types. This keeps the contract boundary clean and allows the web client to reference it without pulling in game engine dependencies.
+
+## Sprint 7 Integration Points
+
+Every `// TODO: Sprint 7` comment in `TerrariumHub` marks where Orleans grain calls will be inserted:
+- `JoinEcosystem` → `PeerGrain.RegisterPeer()`
+- `LeaveEcosystem` → `PeerGrain.RevokeLease()`
+- `TeleportCreature` → `PeerGrain` for routing, `EcosystemGrain` for validation
+- `AnnouncePeer` → `PeerGrain` for lease management
+- `RequestWorldState` → `EcosystemGrain.GetWorldState()`
+- `OnDisconnectedAsync` → `PeerGrain.RevokeLease()`
+
+## Why This Matters
+
+The legacy networking stack (`HttpWebListener`, `NetworkEngine`, `PeerManager`) is ~3000 lines of custom TCP socket code, HTTP parsing, and binary serialization. The replacement is ~250 lines of typed interfaces and a thin hub. SignalR handles transport, reconnection, and message serialization. Orleans will handle state, leasing, and routing.

--- a/src/Terrarium.Server/PeerDiscoveryEndpoints.cs
+++ b/src/Terrarium.Server/PeerDiscoveryEndpoints.cs
@@ -1,0 +1,231 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+
+namespace Terrarium.Server;
+
+/// <summary>
+/// Result codes returned by the peer registration endpoint.
+/// Ported from Server/Website/App_Code/Discovery/DiscoveryDB.asmx.cs.
+/// </summary>
+public enum RegisterPeerResult
+{
+    Success,
+    Failure,
+    GlobalFailure
+}
+
+/// <summary>
+/// A peer entry returned from the discovery stored procedure.
+/// </summary>
+public sealed class PeerInfo
+{
+    public string IPAddress { get; set; } = string.Empty;
+    public DateTime Lease { get; set; }
+}
+
+/// <summary>
+/// Request body for POST /api/discovery/register.
+/// </summary>
+public sealed class RegisterPeerRequest
+{
+    public string Version { get; set; } = string.Empty;
+    public string Channel { get; set; } = string.Empty;
+    public Guid Guid { get; set; }
+}
+
+/// <summary>
+/// Response from POST /api/discovery/register.
+/// </summary>
+public sealed class RegisterPeerResponse
+{
+    public RegisterPeerResult Result { get; set; }
+    public int PeerCount { get; set; }
+    public List<PeerInfo> Peers { get; set; } = [];
+}
+
+/// <summary>
+/// Request body for POST /api/discovery/register-user.
+/// </summary>
+public sealed class RegisterUserRequest
+{
+    public string Email { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Response from GET /api/discovery/peers.
+/// </summary>
+public sealed class PeerCountResponse
+{
+    public int Count { get; set; }
+}
+
+/// <summary>
+/// Request for checking if a version is disabled.
+/// </summary>
+public sealed class VersionCheckResponse
+{
+    public bool Disabled { get; set; }
+    public string Message { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Minimal API endpoints for the PeerDiscovery service.
+/// Ported from Server/Website/App_Code/Discovery/DiscoveryDB.asmx.cs.
+/// </summary>
+public static class PeerDiscoveryEndpoints
+{
+    public static RouteGroupBuilder MapPeerDiscoveryEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/register", async (
+            RegisterPeerRequest request,
+            HttpContext httpContext,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            if (string.IsNullOrEmpty(request.Version) || string.IsNullOrEmpty(request.Channel))
+            {
+                return Results.Ok(new RegisterPeerResponse { Result = RegisterPeerResult.GlobalFailure });
+            }
+
+            var fullVersion = new Version(request.Version).ToString(4);
+            var version = new Version(request.Version).ToString(3);
+            var ipAddress = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var parameters = new DynamicParameters();
+                parameters.Add("@Version", version, DbType.String, size: 255);
+                parameters.Add("@FullVersion", fullVersion, DbType.String, size: 255);
+                parameters.Add("@Channel", request.Channel, DbType.String, size: 255);
+                parameters.Add("@IPAddress", ipAddress, DbType.String, size: 50);
+                parameters.Add("@Guid", request.Guid, DbType.Guid);
+                parameters.Add("@Disabled_Error", dbType: DbType.Boolean, direction: ParameterDirection.Output);
+                parameters.Add("@PeerCount", dbType: DbType.Int32, direction: ParameterDirection.Output);
+
+                var peers = (await connection.QueryAsync<PeerInfo>(
+                    "TerrariumRegisterPeerCountAndList",
+                    parameters,
+                    commandType: CommandType.StoredProcedure)).ToList();
+
+                var disabled = parameters.Get<bool>("@Disabled_Error");
+                var peerCount = parameters.Get<int>("@PeerCount");
+
+                if (disabled)
+                {
+                    return Results.Ok(new RegisterPeerResponse { Result = RegisterPeerResult.GlobalFailure });
+                }
+
+                return Results.Ok(new RegisterPeerResponse
+                {
+                    Result = RegisterPeerResult.Success,
+                    PeerCount = peerCount,
+                    Peers = peers
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "PeerDiscovery: RegisterPeer failed");
+                return Results.Ok(new RegisterPeerResponse { Result = RegisterPeerResult.Failure });
+            }
+        });
+
+        group.MapGet("/peers", async (
+            string version,
+            string channel,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            if (string.IsNullOrEmpty(version) || string.IsNullOrEmpty(channel))
+            {
+                return Results.Ok(new PeerCountResponse { Count = 0 });
+            }
+
+            var normalizedVersion = new Version(version).ToString(3);
+
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var count = await connection.ExecuteScalarAsync<int?>(
+                    "TerrariumGrabNumPeers",
+                    new { Version = normalizedVersion, Channel = channel },
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(new PeerCountResponse { Count = count ?? 0 });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "PeerDiscovery: GetNumPeers failed");
+                return Results.Ok(new PeerCountResponse { Count = 0 });
+            }
+        });
+
+        group.MapGet("/validate", (HttpContext httpContext) =>
+        {
+            var ipAddress = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            return Results.Ok(new { ipAddress });
+        });
+
+        group.MapPost("/register-user", async (
+            RegisterUserRequest request,
+            HttpContext httpContext,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            var ipAddress = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                await connection.ExecuteAsync(
+                    "TerrariumRegisterUser",
+                    new { Email = request.Email, IPAddress = ipAddress },
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(new { success = true });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "PeerDiscovery: RegisterUser failed");
+                return Results.Ok(new { success = false });
+            }
+        });
+
+        group.MapGet("/version-check", async (
+            string version,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            try
+            {
+                var fullVersion = new Version(version).ToString(4);
+                var normalizedVersion = new Version(version).ToString(3);
+
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var result = await connection.QueryFirstOrDefaultAsync<VersionCheckResponse>(
+                    "TerrariumIsVersionDisabled",
+                    new { Version = normalizedVersion, FullVersion = fullVersion },
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(result ?? new VersionCheckResponse { Disabled = true, Message = string.Empty });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "PeerDiscovery: IsVersionDisabled failed");
+                return Results.Ok(new VersionCheckResponse { Disabled = true, Message = string.Empty });
+            }
+        });
+
+        return group;
+    }
+}

--- a/src/Terrarium.Server/Program.cs
+++ b/src/Terrarium.Server/Program.cs
@@ -19,6 +19,15 @@ app.MapGet("/", () => "Terrarium Server");
 app.MapGroup("/api/messaging")
     .MapMessagingEndpoints();
 
+app.MapGroup("/api/discovery")
+    .MapPeerDiscoveryEndpoints();
+
+app.MapGroup("/api/watson")
+    .MapWatsonEndpoints();
+
+app.MapGroup("/api/bugs")
+    .MapBugEndpoints();
+
 app.Run();
 
 // Make Program visible to integration tests using WebApplicationFactory<Program>

--- a/src/Terrarium.Server/WatsonEndpoints.cs
+++ b/src/Terrarium.Server/WatsonEndpoints.cs
@@ -1,0 +1,98 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+
+namespace Terrarium.Server;
+
+/// <summary>
+/// Request body for POST /api/watson/report.
+/// Ported from Server/Website/App_Code/Watson/Watson.asmx.cs.
+/// </summary>
+public sealed class WatsonReportRequest
+{
+    public string LogType { get; set; } = string.Empty;
+    public string OSVersion { get; set; } = string.Empty;
+    public string GameVersion { get; set; } = string.Empty;
+    public string CLRVersion { get; set; } = string.Empty;
+    public string ErrorLog { get; set; } = string.Empty;
+    public string UserEmail { get; set; } = string.Empty;
+    public string UserComment { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Request body for POST /api/bugs/report.
+/// Ported from Server/Website/App_Code/BugService.cs (stub in legacy).
+/// </summary>
+public sealed class BugReportRequest
+{
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Alias { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Minimal API endpoints for the Watson error reporting and Bug reporting services.
+/// Watson: ported from Server/Website/App_Code/Watson/Watson.asmx.cs.
+/// Bug: ported from Server/Website/App_Code/BugService.cs (was a stub/TODO in legacy).
+/// </summary>
+public static class WatsonEndpoints
+{
+    public static RouteGroupBuilder MapWatsonEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/report", async (
+            WatsonReportRequest request,
+            HttpContext httpContext,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            try
+            {
+                var machineName = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                await connection.ExecuteAsync(
+                    "TerrariumInsertWatson",
+                    new
+                    {
+                        request.LogType,
+                        MachineName = machineName,
+                        request.OSVersion,
+                        request.GameVersion,
+                        request.CLRVersion,
+                        request.ErrorLog,
+                        request.UserComment,
+                        request.UserEmail
+                    },
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(new { success = true });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Watson: ReportError failed");
+                return Results.Ok(new { success = false });
+            }
+        });
+
+        return group;
+    }
+
+    public static RouteGroupBuilder MapBugEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/report", (
+            BugReportRequest request,
+            ILogger<Program> logger) =>
+        {
+            // Legacy BugService was a stub (TODO in code). Log the report for now.
+            logger.LogInformation("Bug report received: {Title} from {Alias}", request.Title, request.Alias);
+            return Results.Ok(new { success = true });
+        });
+
+        return group;
+    }
+}


### PR DESCRIPTION
## Summary

Ports the PeerDiscovery and Watson/Bug ASMX services to ASP.NET Core Minimal API endpoints using Dapper for stored procedure access.

### PeerDiscovery endpoints (Closes #17)

| Method | Route | Stored Procedure | Description |
|--------|-------|-----------------|-------------|
| POST | \/api/discovery/register\ | TerrariumRegisterPeerCountAndList | Heartbeat — registers peer, returns peer list + count |
| GET | \/api/discovery/peers\ | TerrariumGrabNumPeers | Returns peer count for version/channel |
| GET | \/api/discovery/validate\ | — | Returns caller's IP address |
| POST | \/api/discovery/register-user\ | TerrariumRegisterUser | Registers user email |
| GET | \/api/discovery/version-check\ | TerrariumIsVersionDisabled | Version kill-switch check |

### Watson + Bug endpoints (Closes #18)

| Method | Route | Stored Procedure | Description |
|--------|-------|-----------------|-------------|
| POST | \/api/watson/report\ | TerrariumInsertWatson | Error/crash report insert |
| POST | \/api/bugs/report\ | — (stub) | Bug report logging (legacy was a TODO) |

### Design decisions

- **Dapper for all SQL** — matches Sprint 1 decision. No raw ADO.NET.
- **Follows MessagingEndpoints pattern** — RouteGroupBuilder extension methods, same DI approach.
- **RegisterPeerResult enum** — ported directly from legacy, used in JSON response.
- **Legacy DataSet returns to typed POCOs** — PeerInfo replaces DataSet rows.
- **BugService remains a stub** — legacy code was \//TODO: Add code to report bugs\. We log the report for now.
- **Error handling** — matches legacy behavior: catch-all returns failure/zero rather than 500s.

### Build and test

- \dotnet build src/Terrarium.sln\ — 0 warnings, 0 errors
- \dotnet test src/Terrarium.Server.Tests\ — 17 passed, 0 failed