### PR TITLE
Port Terrarium.Configuration with IOptions and ILogger

### DIFF
--- a/.ai-team/agents/heisenberg/history.md
+++ b/.ai-team/agents/heisenberg/history.md
@@ -89,3 +89,16 @@
 📌 Team update (2026-02-11): Solution uses classic .sln (not .slnx), CS1591 suppressed during port — decided by Heisenberg
 📌 Team update (2026-02-11): Aspire packages pinned — Aspire 13.1.0, ServiceDiscovery/Resilience 10.3.0, OpenTelemetry 1.15.0 — decided by Saul
 📌 Team update (2026-02-11): CSS token naming: --glass-{category}-{element}-{modifier}, BEM for components — decided by Jesse
+
+### 2025-07-16 — Terrarium.Configuration Ported (#15)
+
+- **Ported:** `Client/Configuration/` → `src/Terrarium.Configuration/` as a clean .NET 10 class library.
+- **GameSettings** replaces static `GameConfig`. Uses `IOptions<GameSettings>` pattern with `BindConfiguration("Game")` and DataAnnotations validation (`[Range(50,200)]` on CpuThrottle). All 20+ legacy config properties preserved with matching defaults.
+- **ErrorLog** modernized from static class with `Mutex`/`DataSet`/WinForms to DI-injected service using `ILogger<ErrorLog>`. No more `System.Data.DataSet`, no `Mutex`, no `System.Windows.Forms`.
+- **TimeMonitor** replaced `QueryPerformanceCounter`/`QueryPerformanceFrequency` P/Invokes with `System.Diagnostics.Stopwatch`.
+- **Profiler/ProfilerNode** modernized: `Hashtable` → `ConcurrentDictionary`, `#if TRACE` removed (always available), public properties exposed on `ProfilerNode`.
+- **CountrySettings/StateSettings** ported as static classes with `Array.Exists` validation.
+- **Skipped:** `TerrariumTraceListener` (WinForms `DefaultTraceListener` subclass), `ReportBug` (WinForms dialog), `CachedBooleanConfig` (replaced by `IOptions<T>` pattern).
+- **DI registration:** `services.AddTerrariumConfiguration()` wires up `IOptions<GameSettings>` + `ErrorLog` singleton.
+- **Packages:** `Microsoft.Extensions.Options.DataAnnotations`, `Microsoft.Extensions.Options.ConfigurationExtensions`, `Microsoft.Extensions.Logging.Abstractions`, `Microsoft.Extensions.Configuration.Binder` (all 10.0.0).
+- **Build:** Clean build, 0 errors, 0 warnings across entire solution.

--- a/.ai-team/decisions/inbox/heisenberg-configuration-patterns.md
+++ b/.ai-team/decisions/inbox/heisenberg-configuration-patterns.md
@@ -1,0 +1,27 @@
+# Decision: Terrarium.Configuration Patterns
+
+**By:** Heisenberg (Lead / Architect)
+**Date:** 2025-07-16
+**Status:** Implemented (PR for #15)
+
+## What
+
+1. **`IOptions<GameSettings>` replaces static `GameConfig`.** All game configuration goes through `IOptions<GameSettings>` / `IOptionsSnapshot<GameSettings>` / `IOptionsMonitor<GameSettings>`. No more static mutable singletons. The `"Game"` section of `appsettings.json` is the binding target.
+
+2. **DataAnnotations validation on start.** `ValidateOnStart()` catches misconfiguration before the app serves traffic. Currently validates `CpuThrottle` range (50–200).
+
+3. **`ErrorLog` is an injected service, not a static class.** Takes `ILogger<ErrorLog>` via constructor. No `Mutex`, no `DataSet`, no `System.Windows.Forms`.
+
+4. **`TimeMonitor` uses `Stopwatch`, not P/Invoke.** `QueryPerformanceCounter`/`QueryPerformanceFrequency` replaced with `System.Diagnostics.Stopwatch`. Same API shape (`Start()`, `EndGetMicroseconds()`, `GetCounterSeconds()`).
+
+5. **WinForms UI classes not ported.** `TerrariumTraceListener`, `ReportBug`, and `CachedBooleanConfig` are legacy artifacts. The trace listener depended on `System.Windows.Forms.Timer`; the bug reporter was a WinForms dialog calling ASMX. These belong to a future UI layer, not a configuration library.
+
+## Why
+
+The original `GameConfig` was a static class reading/writing XML via `XmlDocument` to `~/Documents/Terrarium/userconfig.xml`. Every property had its own cached field with lazy initialization — classic .NET 1.x pattern. Moving to `IOptions<T>` makes the configuration injectable, testable, and compatible with the standard ASP.NET Core configuration pipeline (`appsettings.json`, environment variables, Azure App Configuration, etc.).
+
+## Impact
+
+- Any project needing game configuration should reference `Terrarium.Configuration` and inject `IOptions<GameSettings>`.
+- Call `services.AddTerrariumConfiguration()` in your DI setup.
+- The `Profiler`/`ProfilerNode`/`TimeMonitor` classes are available for any project that needs performance measurement.

--- a/src/Terrarium.Configuration/ConfigurationServiceExtensions.cs
+++ b/src/Terrarium.Configuration/ConfigurationServiceExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Terrarium.Configuration;
+
+/// <summary>
+/// Extension methods to register Terrarium configuration services.
+/// </summary>
+public static class ConfigurationServiceExtensions
+{
+    /// <summary>
+    /// Adds <see cref="GameSettings"/> via <c>IOptions&lt;GameSettings&gt;</c> with
+    /// DataAnnotations validation, and registers <see cref="ErrorLog"/> as a singleton.
+    /// </summary>
+    public static IServiceCollection AddTerrariumConfiguration(this IServiceCollection services)
+    {
+        services.AddOptions<GameSettings>()
+            .BindConfiguration(GameSettings.SectionName)
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddSingleton<ErrorLog>();
+
+        return services;
+    }
+}

--- a/src/Terrarium.Configuration/CountrySettings.cs
+++ b/src/Terrarium.Configuration/CountrySettings.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace Terrarium.Configuration;
+
+/// <summary>
+/// Enumerates and validates countries/regions for peer teleportation metadata.
+/// </summary>
+public static class CountrySettings
+{
+    public static readonly string[] Countries =
+    [
+        "Afghanistan",          "Albania",          "Algeria",          "Andorra",
+        "Angola",               "Antigua & Barbuda","Argentina",        "Armenia",
+        "Australia",            "Austria",          "Azerbaijan",       "Bahamas, The",
+        "Bahrain",              "Bangladesh",       "Barbados",         "Belarus",
+        "Belgium",              "Belize",           "Benin",            "Bhutan",
+        "Bolivia",              "Bosnia & Herz.",   "Botswana",         "Brazil",
+        "Brunei",               "Bulgaria",         "Burkina Faso",     "Burundi",
+        "Cote d'Ivoire",        "C.A.R.",           "Cambodia",         "Cameroon",
+        "Canada",               "Cape Verde",       "Chad",             "Chile",
+        "China",                "Colombia",         "Comoros",          "Congo (DRC)",
+        "Costa Rica",           "Croatia",          "Cuba",             "Cyprus",
+        "Czech Republic",       "Denmark",          "Djibouti",         "Dominica",
+        "Dominican Rep.",       "Ecuador",          "Egypt",            "El Salvador",
+        "Equatorial Guinea",    "Eritrea",          "Estonia",          "Ethiopia",
+        "Fiji Islands",         "Finland",          "France",
+        "Gabon",                "Gambia, The",      "Georgia",          "Germany",
+        "Ghana",                "Greece",           "Grenada",          "Guatemala",
+        "Guinea",               "Guinea-Bissau",    "Guyana",           "Haiti",
+        "Honduras",             "Hungary",          "Iceland",          "India",
+        "Indonesia",            "Iran",             "Iraq",             "Ireland",
+        "Israel",               "Italy",            "Jamaica",          "Japan",
+        "Jordan",               "Kazakhstan",       "Kenya",            "Kiribati",
+        "Kuwait",               "Kyrgyzstan",       "Laos",             "Latvia",
+        "Lebanon",              "Lesotho",          "Liberia",          "Libya",
+        "Liechtenstein",        "Lithuania",        "Luxembourg",
+        "Macedonia, Former Yugoslav Republic of",
+        "Madagascar",           "Malawi",           "Malaysia",         "Maldives",
+        "Mali",                 "Malta",            "Marshall Islands", "Mauritania",
+        "Mauritius",
+        "Mexico",               "Micronesia",       "Monaco",           "Mongolia",
+        "Morocco",              "Mozambique",       "Myanmar",          "Namibia",
+        "Nauru",                "Nepal",            "Netherlands, The",
+        "New Zealand",          "Nicaragua",        "Niger",            "Nigeria",
+        "North Korea",          "Norway",           "Oman",             "Pakistan",
+        "Palau",                "Panama",           "Papua New Guinea", "Paraguay",
+        "Peru",                 "Philippines",      "Poland",           "Portugal",
+        "Qatar",                "Rep. of Congo",    "Republic of Moldova", "Romania",
+        "Russia",               "Rwanda",           "Sao Tome & Prin.", "Samoa",
+        "San Marino",           "Saudi Arabia",     "Senegal",          "Seychelles",
+        "Sierra Leone",         "Singapore",        "Slovakiav",        "Slovenia",
+        "Solomon Islands",      "Somalia",          "South Africa",     "South Korea",
+        "Spain",                "Sri Lanka",        "St. Kitts & Nevis","St. Lucia",
+        "St. Vincent & Gren.",  "Sudan",            "Suriname",         "Swaziland",
+        "Sweden",               "Switzerland",      "Syria",            "Tajikistan",
+        "Tanzania",             "Thailand",         "Togo",             "Tonga",
+        "Trinidad & Tobago",    "Tunisia",          "Turkey",           "Turkmenistan",
+        "Tuvalu",               "U.A.E.",           "Uganda",           "Ukraine",
+        "United Kingdom",       "United States",    "Uruguay",          "Uzbekistan",
+        "Vanuatu",              "Vatican City",     "Venezuela",        "Vietnam",
+        "Yemen",                "Zambia",           "Zimbabwe",         "<Unknown>"
+    ];
+
+    /// <summary>
+    /// Returns true if the given string matches a known country/region exactly.
+    /// </summary>
+    public static bool Validate(string country)
+        => Array.Exists(Countries, c => c == country);
+}

--- a/src/Terrarium.Configuration/ErrorLog.cs
+++ b/src/Terrarium.Configuration/ErrorLog.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+
+namespace Terrarium.Configuration;
+
+/// <summary>
+/// Centralized error logging using <see cref="ILogger"/> instead of the legacy
+/// file-based / DataSet-based approach.
+/// </summary>
+public sealed class ErrorLog
+{
+    private readonly ILogger<ErrorLog> _logger;
+
+    public ErrorLog(ILogger<ErrorLog> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Log a handled exception at Debug level.
+    /// </summary>
+    public void LogHandledException(Exception e)
+    {
+        _logger.LogDebug(e, "Handled exception: {Message}", FormatException(e));
+    }
+
+    /// <summary>
+    /// Log a failed assertion at Error level.
+    /// </summary>
+    public void LogFailedAssertion(string message, string traces = "")
+    {
+        _logger.LogError("Assertion failure: {Message} Traces: {Traces}", message, traces);
+    }
+
+    /// <summary>
+    /// Formats an exception with special handling for <see cref="SocketException"/>.
+    /// </summary>
+    public static string FormatException(Exception e)
+    {
+        if (e is SocketException socketEx)
+        {
+            return $"SocketException({socketEx.SocketErrorCode}): {e.Message}\r\n{e.StackTrace}";
+        }
+
+        return e.ToString();
+    }
+}

--- a/src/Terrarium.Configuration/GameSettings.cs
+++ b/src/Terrarium.Configuration/GameSettings.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Terrarium.Configuration;
+
+/// <summary>
+/// Strongly typed game configuration. Replaces the legacy static <c>GameConfig</c> class.
+/// Bind to the <c>"Game"</c> section of appsettings.json and validate via DataAnnotations.
+/// </summary>
+public sealed class GameSettings
+{
+    public const string SectionName = "Game";
+
+    // --- Rendering ---
+
+    public bool BackgroundGrid { get; set; }
+
+    public bool BoundingBoxes { get; set; }
+
+    public bool DestinationLines { get; set; }
+
+    public bool DrawScreen { get; set; } = true;
+
+    public bool LargeGraphicsMode { get; set; }
+
+    // --- Behavior ---
+
+    public bool DemoMode { get; set; }
+
+    public bool SkipVersionCheck { get; set; }
+
+    public bool StartFullscreen { get; set; }
+
+    public bool ScreenSaverSpanMonitors { get; set; }
+
+    public bool UseSimpleScreenSaver { get; set; }
+
+    // --- Networking ---
+
+    public bool EnableNat { get; set; }
+
+    public bool UseConfigForDiscovery { get; set; }
+
+    public string PeerList { get; set; } = string.Empty;
+
+    public string LocalIPAddress { get; set; } = string.Empty;
+
+    public string WebRoot { get; set; } = "http://www.terrariumserver.com";
+
+    // --- User info ---
+
+    public string UserCountry { get; set; } = "<Unknown>";
+
+    public string UserState { get; set; } = "<Unknown>";
+
+    public string UserEmail { get; set; } = string.Empty;
+
+    // --- Display / Theme ---
+
+    public string StyleName { get; set; } = "Graphite";
+
+    public string LoggingMode { get; set; } = string.Empty;
+
+    // --- Performance ---
+
+    [Range(50, 200)]
+    public int CpuThrottle { get; set; } = 100;
+
+    // --- Version ---
+
+    public string BlockedVersion { get; set; } = string.Empty;
+
+    // --- Derived (read-only) ---
+
+    public bool ShowErrors => !DemoMode;
+
+    public bool AllowUpdates => !DemoMode;
+}

--- a/src/Terrarium.Configuration/Profiler.cs
+++ b/src/Terrarium.Configuration/Profiler.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Collections.Concurrent;
+
+namespace Terrarium.Configuration;
+
+/// <summary>
+/// Collects named profiling nodes for performance measurement.
+/// </summary>
+public sealed class Profiler
+{
+    private ConcurrentDictionary<string, ProfilerNode> _nodes = new();
+
+    public ProfilerNode? this[string key]
+        => _nodes.TryGetValue(key, out var node) ? node : null;
+
+    public ProfilerNode[] Nodes => [.. _nodes.Values];
+
+    public void ClearProfiler()
+    {
+        _nodes = new ConcurrentDictionary<string, ProfilerNode>();
+    }
+
+    public void Start(string functionName)
+    {
+        var node = _nodes.GetOrAdd(functionName, static name => new ProfilerNode(name));
+        node.Start();
+    }
+
+    public void End(string functionName)
+    {
+        if (_nodes.TryGetValue(functionName, out var node))
+        {
+            node.End();
+        }
+    }
+}

--- a/src/Terrarium.Configuration/ProfilerNode.cs
+++ b/src/Terrarium.Configuration/ProfilerNode.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace Terrarium.Configuration;
+
+/// <summary>
+/// Represents a single named profiling measurement.
+/// </summary>
+public sealed class ProfilerNode
+{
+    private readonly TimeMonitor _timeMonitor = new();
+    private bool _isCounting;
+
+    public ProfilerNode(string id)
+    {
+        Id = id;
+    }
+
+    public string Id { get; }
+
+    /// <summary>Time consumed by the last call, in microseconds.</summary>
+    public long LastTime { get; private set; }
+
+    /// <summary>Total time consumed across all calls, in microseconds.</summary>
+    public long RunningTotal { get; private set; }
+
+    /// <summary>Number of completed timing samples.</summary>
+    public int Samples { get; private set; }
+
+    public void Start()
+    {
+        _isCounting = true;
+        _timeMonitor.Start();
+    }
+
+    public void End()
+    {
+        if (!_isCounting) return;
+        _isCounting = false;
+        LastTime = _timeMonitor.EndGetMicroseconds();
+        RunningTotal += LastTime;
+        Samples++;
+    }
+}

--- a/src/Terrarium.Configuration/StateSettings.cs
+++ b/src/Terrarium.Configuration/StateSettings.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace Terrarium.Configuration;
+
+/// <summary>
+/// Enumerates and validates US states for peer teleportation metadata.
+/// </summary>
+public static class StateSettings
+{
+    public static readonly string[] States =
+    [
+        "Alabama",              "Alaska",           "Arizona",          "Arkansas",
+        "California",           "Colorado",         "Connecticut",      "Delaware",
+        "District of Columbia", "Florida",          "Georgia",          "Hawaii",
+        "Idaho",                "Illinois",         "Indiana",          "Iowa",
+        "Kansas",               "Kentucky",         "Louisiana",        "Maine",
+        "Maryland",             "Massachusetts",    "Michigan",         "Minnesota",
+        "Mississippi",          "Missouri",         "Montana",          "Nebraska",
+        "Nevada",               "New Hampshire",    "New Jersey",       "New Mexico",
+        "New York",             "North Carolina",   "North Dakota",     "Ohio",
+        "Oklahoma",             "Oregon",           "Pennsylvania",     "Rhode Island",
+        "South Carolina",       "South Dakota",     "Tennessee",        "Texas",
+        "Utah",                 "Vermont",          "Virginia",         "Washington",
+        "West Virginia",        "Wisconsin",        "Wyoming",          "<Unknown>"
+    ];
+
+    /// <summary>
+    /// Returns true if the given string matches one of the 50 US states (+ DC + Unknown).
+    /// </summary>
+    public static bool Validate(string state)
+        => Array.Exists(States, s => s == state);
+}

--- a/src/Terrarium.Configuration/Terrarium.Configuration.csproj
+++ b/src/Terrarium.Configuration/Terrarium.Configuration.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Terrarium.Configuration</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Terrarium.Configuration/TimeMonitor.cs
+++ b/src/Terrarium.Configuration/TimeMonitor.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Diagnostics;
+
+namespace Terrarium.Configuration;
+
+/// <summary>
+/// High-resolution timer using <see cref="Stopwatch"/> instead of the legacy
+/// <c>QueryPerformanceCounter</c> P/Invoke.
+/// </summary>
+public sealed class TimeMonitor
+{
+    private readonly Stopwatch _stopwatch = new();
+
+    /// <summary>
+    /// Whether a timing session is currently in progress.
+    /// </summary>
+    public bool IsStarted => _stopwatch.IsRunning;
+
+    /// <summary>
+    /// Starts (or restarts) the timing session.
+    /// </summary>
+    public void Start()
+    {
+        _stopwatch.Restart();
+    }
+
+    /// <summary>
+    /// Ends the timing session and returns the elapsed time in microseconds.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if Start was not called first.</exception>
+    public long EndGetMicroseconds()
+    {
+        if (!_stopwatch.IsRunning)
+        {
+            throw new InvalidOperationException("Start must be called before calling End.");
+        }
+
+        _stopwatch.Stop();
+        return _stopwatch.Elapsed.Ticks / (TimeSpan.TicksPerMillisecond / 1000);
+    }
+
+    /// <summary>
+    /// Returns the total elapsed seconds since the last <see cref="Start"/> call without stopping.
+    /// </summary>
+    public double GetCounterSeconds()
+    {
+        return _stopwatch.Elapsed.TotalSeconds;
+    }
+}

--- a/src/Terrarium.sln
+++ b/src/Terrarium.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terrarium.ServiceDefaults",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terrarium.Server.Tests", "Terrarium.Server.Tests\Terrarium.Server.Tests.csproj", "{F8FE2B51-C3BF-4279-9307-373FC63068CB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terrarium.Configuration", "Terrarium.Configuration\Terrarium.Configuration.csproj", "{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,18 @@ Global
 		{F8FE2B51-C3BF-4279-9307-373FC63068CB}.Release|x64.Build.0 = Release|Any CPU
 		{F8FE2B51-C3BF-4279-9307-373FC63068CB}.Release|x86.ActiveCfg = Release|Any CPU
 		{F8FE2B51-C3BF-4279-9307-373FC63068CB}.Release|x86.Build.0 = Release|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Debug|x64.Build.0 = Debug|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Debug|x86.Build.0 = Debug|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Release|x64.ActiveCfg = Release|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Release|x64.Build.0 = Release|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Release|x86.ActiveCfg = Release|Any CPU
+		{7A23AE8C-766B-46A0-BEEF-FBFBC1CCF0B4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Closes #15

## What

Ports the legacy \Client/Configuration/\ system to a modern .NET 10 class library at \src/Terrarium.Configuration/\.

### Changes

| Legacy | Modern | Notes |
|--------|--------|-------|
| Static \GameConfig\ with XML | \GameSettings\ + \IOptions<GameSettings>\ | Binds to \ppsettings.json\ \Game\ section |
| \CachedBooleanConfig\ | Eliminated | \IOptions<T>\ handles caching |
| Static \ErrorLog\ with \Mutex\/\DataSet\ | \ErrorLog\ with \ILogger<ErrorLog>\ | DI-injected, no WinForms |
| \TimeMonitor\ with \QueryPerformanceCounter\ P/Invoke | \TimeMonitor\ with \Stopwatch\ | Same API, no P/Invoke |
| \Profiler\ with \Hashtable\ | \Profiler\ with \ConcurrentDictionary\ | Thread-safe, always available |
| \CountrySettings\/\StateSettings\ | Static classes with \Array.Exists\ | Preserved all data |
| \TerrariumTraceListener\/\ReportBug\ | Not ported | WinForms UI — belongs in future UI layer |

### DI Registration

\\\csharp
services.AddTerrariumConfiguration();
\\\

### Validation

- \CpuThrottle\ validated via \[Range(50, 200)]\
- \ValidateOnStart()\ catches bad config at startup

### Build

0 errors, 0 warnings across entire solution.