### PR TITLE
Port Species and Reporting endpoints

### DIFF
--- a/.ai-team/agents/gus/history.md
+++ b/.ai-team/agents/gus/history.md
@@ -76,3 +76,18 @@
 - Default rate limit: 60 requests/IP/minute — matches legacy server's typical throttle window
 - Messaging endpoints return `{ "message": "..." }` / `{ "version": "..." }` JSON — simple, predictable shape
 - No database calls yet — Dapper is referenced but not invoked until discovery/species endpoints are ported
+
+### 2025-07-16 — Sprint 2: Species & Reporting Endpoints (#26, #27)
+
+**What was done:**
+- Created `src/Terrarium.Server/SpeciesEndpoints.cs` — 5 endpoints porting the legacy `SpeciesService` ASMX
+- Created `src/Terrarium.Server/ReportingEndpoints.cs` — 4 endpoints porting `ReportingService` + `ChartService`/`ChartBuilder`
+- Wired both endpoint groups in `Program.cs`
+- PR #120 → `squadified`
+
+**Key decisions:**
+- Assembly file I/O omitted — legacy CAS-based `FileIOPermission` doesn't apply in .NET 10
+- Word filter (PoliCheck) omitted — depends on static file; can be added later
+- `ReportPopulation` returns `Success` on error (matching legacy behavior to prevent retry storms)
+- Chart endpoints consolidated under `/api/reporting/stats/` rather than separate `/api/charts/`
+- `SpeciesServiceStatus` and `ReportingReturnCode` enums ported as-is for client compatibility

--- a/.ai-team/decisions/inbox/gus-species-reporting-endpoints.md
+++ b/.ai-team/decisions/inbox/gus-species-reporting-endpoints.md
@@ -1,0 +1,25 @@
+# Decision: Species & Reporting Endpoint Design
+
+**From:** Gus (Server Dev)
+**Date:** 2025-07-16
+**PR:** #120
+**Issues:** #26, #27
+
+## Decisions Made
+
+### 1. Assembly storage deferred
+The legacy `SpeciesService` stored creature assemblies to disk using `FileIOPermission` (Code Access Security). CAS doesn't exist in .NET 10. Assembly storage needs a separate design decision — likely Azure Blob Storage or a configurable filesystem path without CAS. The `GetSpeciesAssembly` endpoint and `SaveAssembly`/`LoadAssembly`/`RemoveAssembly` methods are not ported. The register endpoint inserts the DB record but does not persist the assembly binary.
+
+### 2. Word filter (PoliCheck) deferred
+The legacy register checked species names, author names, and emails against `invalidwordlist.txt` via `WordFilter.RunQuickWordFilter()`. This is not ported yet — it depends on a static file and the `WordFilter.cs` utility. When ported, it should be a service injected into the endpoint, not a static call.
+
+### 3. Charts consolidated under /api/reporting/stats/
+Rather than creating a separate `/api/charts/` route group, chart data endpoints live under `/api/reporting/stats/`. The legacy `ChartService.asmx` was a thin SOAP wrapper around `ChartBuilder.cs` which just ran stored procedures. The three chart endpoints (`species-list`, `latest`, `top-animals`) are data queries — they belong with reporting.
+
+### 4. ReportPopulation returns Success on server errors
+Matches legacy behavior documented in the original code: "Return success instead of ServerDown because, if the server is getting hammered, Success will tell clients to stop retrying, where ServerDown will tell them to keep doing it."
+
+## Impact
+- **Mike/Jesse (client devs):** Species API contract is defined. When the client needs to register/list/reintroduce species, these are the endpoints.
+- **Hank (tester):** 9 new endpoints to cover. Integration tests will need a SQL Server container with the init script.
+- **Saul (DevOps):** No new infrastructure needed — endpoints use the existing `SpeciesDsn` connection string from `ServerSettings`.

--- a/src/Terrarium.Server/Program.cs
+++ b/src/Terrarium.Server/Program.cs
@@ -28,6 +28,12 @@ app.MapGroup("/api/watson")
 app.MapGroup("/api/bugs")
     .MapBugEndpoints();
 
+app.MapGroup("/api/species")
+    .MapSpeciesEndpoints();
+
+app.MapGroup("/api/reporting")
+    .MapReportingEndpoints();
+
 app.Run();
 
 // Make Program visible to integration tests using WebApplicationFactory<Program>

--- a/src/Terrarium.Server/ReportingEndpoints.cs
+++ b/src/Terrarium.Server/ReportingEndpoints.cs
@@ -1,0 +1,344 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using Terrarium.Server.Middleware;
+
+namespace Terrarium.Server;
+
+/// <summary>
+/// Return codes for the reporting service.
+/// Ported from Server/Website/App_Code/Reporting/ReportPopulation.asmx.cs.
+/// </summary>
+public enum ReportingReturnCode
+{
+    Success = 0,
+    AlreadyExists = 1,
+    ServerDown = 2,
+    NodeTimedOut = 3,
+    NodeCorrupted = 4,
+    OrganismBlacklisted = 5
+}
+
+/// <summary>
+/// A single row of population data reported by a client.
+/// </summary>
+public sealed class PopulationHistoryRow
+{
+    public Guid Guid { get; set; }
+    public int TickNumber { get; set; }
+    public string SpeciesName { get; set; } = string.Empty;
+    public DateTime ClientTime { get; set; }
+    public int CorrectTime { get; set; }
+    public int Population { get; set; }
+    public int BirthCount { get; set; }
+    public int TeleportedToCount { get; set; }
+    public int StarvedCount { get; set; }
+    public int KilledCount { get; set; }
+    public int TeleportedFromCount { get; set; }
+    public int ErrorCount { get; set; }
+    public int TimeoutCount { get; set; }
+    public int SickCount { get; set; }
+    public int OldAgeCount { get; set; }
+    public int SecurityViolationCount { get; set; }
+}
+
+/// <summary>
+/// Request body for POST /api/reporting/population.
+/// </summary>
+public sealed class ReportPopulationRequest
+{
+    public Guid Guid { get; set; }
+    public int CurrentTick { get; set; }
+    public List<PopulationHistoryRow> History { get; set; } = [];
+}
+
+/// <summary>
+/// Response from POST /api/reporting/population.
+/// </summary>
+public sealed class ReportPopulationResponse
+{
+    public ReportingReturnCode ReturnCode { get; set; }
+}
+
+/// <summary>
+/// A species data point from the DailyPopulation table.
+/// </summary>
+public sealed class SpeciesPopulationData
+{
+    public DateTime SampleDateTime { get; set; }
+    public string SpeciesName { get; set; } = string.Empty;
+    public int Population { get; set; }
+    public int BirthCount { get; set; }
+    public int StarvedCount { get; set; }
+    public int KilledCount { get; set; }
+    public int ErrorCount { get; set; }
+    public int TimeoutCount { get; set; }
+    public int SickCount { get; set; }
+    public int OldAgeCount { get; set; }
+    public int SecurityViolationCount { get; set; }
+}
+
+/// <summary>
+/// A species info record joined with population data.
+/// Returned by the TerrariumGrabSpeciesInfo stored procedure.
+/// </summary>
+public sealed class SpeciesWithPopulation
+{
+    public string SpeciesName { get; set; } = string.Empty;
+    public string AuthorName { get; set; } = string.Empty;
+    public string AuthorEmail { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+    public int Population { get; set; }
+    public string Type { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A top-animal entry returned by the TerrariumTopAnimals stored procedure.
+/// </summary>
+public sealed class TopAnimalEntry
+{
+    public string Name { get; set; } = string.Empty;
+    public string AuthorName { get; set; } = string.Empty;
+    public int Population { get; set; }
+}
+
+/// <summary>
+/// Minimal API endpoints for the Reporting and Charts services.
+/// Reporting: ported from Server/Website/App_Code/Reporting/ReportPopulation.asmx.cs.
+/// Charts: ported from Server/Website/App_Code/Charts/ChartService.asmx.cs and ChartBuilder.cs.
+/// </summary>
+public static class ReportingEndpoints
+{
+    public static RouteGroupBuilder MapReportingEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/population", async (
+            ReportPopulationRequest request,
+            HttpContext httpContext,
+            IOptions<ServerSettings> settings,
+            ThrottleService throttle,
+            ILogger<Program> logger) =>
+        {
+            try
+            {
+                if (request.Guid == Guid.Empty || request.History.Count == 0)
+                {
+                    return Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.Success });
+                }
+
+                var ipAddress = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+                // Check for blacklisted species
+                using var checkConnection = new SqlConnection(settings.Value.SpeciesDsn);
+                await checkConnection.OpenAsync();
+
+                foreach (var row in request.History)
+                {
+                    var blacklisted = await checkConnection.ExecuteScalarAsync<int?>(
+                        "TerrariumCheckSpeciesBlackList",
+                        new { Name = row.SpeciesName },
+                        commandType: CommandType.StoredProcedure);
+
+                    if (blacklisted is 1)
+                    {
+                        return Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.OrganismBlacklisted });
+                    }
+                }
+
+                // Check throttles
+                if (throttle.IsThrottled(ipAddress, "ReportPopulation3Mins"))
+                {
+                    return Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.Success });
+                }
+
+                if (throttle.IsThrottled(ipAddress, "ReportPopulation12Hour"))
+                {
+                    return Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.Success });
+                }
+
+                throttle.AddThrottle(ipAddress, "ReportPopulation3Mins", 1, TimeSpan.FromMinutes(3));
+
+                var contactTime = DateTime.UtcNow;
+
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+                using var transaction = await connection.BeginTransactionAsync();
+
+                // Call TerrariumTimeoutReport
+                var timeoutParams = new DynamicParameters();
+                timeoutParams.Add("@Guid", request.Guid, DbType.Guid);
+                timeoutParams.Add("@LastContact", contactTime, DbType.DateTime);
+                timeoutParams.Add("@LastTick", request.CurrentTick, DbType.Int32);
+                timeoutParams.Add("@ReturnCode", dbType: DbType.Int32, direction: ParameterDirection.Output);
+
+                await connection.ExecuteAsync(
+                    "TerrariumTimeoutReport",
+                    timeoutParams,
+                    (System.Data.Common.DbTransaction)transaction,
+                    commandType: CommandType.StoredProcedure);
+
+                var returnCode = timeoutParams.Get<int>("@ReturnCode");
+                if (returnCode != 0)
+                {
+                    return returnCode switch
+                    {
+                        1 => Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.NodeTimedOut }),
+                        2 => Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.NodeCorrupted }),
+                        _ => Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.ServerDown })
+                    };
+                }
+
+                // Validate and insert history rows
+                if (request.History.Count > 600)
+                {
+                    await transaction.RollbackAsync();
+                    return Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.Success });
+                }
+
+                var totalPopulation = 0;
+                var validRecord = true;
+                var foundBlacklisted = false;
+
+                foreach (var row in request.History)
+                {
+                    if (row.TickNumber != request.CurrentTick)
+                        continue;
+
+                    totalPopulation += row.Population;
+                    if (totalPopulation > 600 || row.Population > 340 || row.Population < 0)
+                    {
+                        validRecord = false;
+                        break;
+                    }
+
+                    var correctTime = row.TickNumber == request.CurrentTick ? row.CorrectTime : 0;
+
+                    var historyParams = new DynamicParameters();
+                    historyParams.Add("@Guid", row.Guid, DbType.Guid);
+                    historyParams.Add("@SpeciesName", row.SpeciesName, DbType.String, size: 255);
+                    historyParams.Add("@ContactTime", contactTime, DbType.DateTime);
+                    historyParams.Add("@ClientTime", row.ClientTime, DbType.DateTime);
+                    historyParams.Add("@CorrectTime", (byte)correctTime, DbType.Byte);
+                    historyParams.Add("@TickNumber", row.TickNumber, DbType.Int32);
+                    historyParams.Add("@Population", row.Population, DbType.Int32);
+                    historyParams.Add("@BirthCount", row.BirthCount, DbType.Int32);
+                    historyParams.Add("@TeleportedToCount", row.TeleportedToCount, DbType.Int32);
+                    historyParams.Add("@StarvedCount", row.StarvedCount, DbType.Int32);
+                    historyParams.Add("@KilledCount", row.KilledCount, DbType.Int32);
+                    historyParams.Add("@TeleportedFromCount", row.TeleportedFromCount, DbType.Int32);
+                    historyParams.Add("@ErrorCount", row.ErrorCount, DbType.Int32);
+                    historyParams.Add("@TimeoutCount", row.TimeoutCount, DbType.Int32);
+                    historyParams.Add("@SickCount", row.SickCount, DbType.Int32);
+                    historyParams.Add("@OldAgeCount", row.OldAgeCount, DbType.Int32);
+                    historyParams.Add("@SecurityViolationCount", row.SecurityViolationCount, DbType.Int32);
+                    historyParams.Add("@BlackListed", dbType: DbType.Int32, direction: ParameterDirection.Output);
+
+                    await connection.ExecuteAsync(
+                        "TerrariumInsertHistory",
+                        historyParams,
+                        (System.Data.Common.DbTransaction)transaction,
+                        commandType: CommandType.StoredProcedure);
+
+                    var bl = historyParams.Get<int?>("@BlackListed");
+                    if (bl is 1)
+                    {
+                        foundBlacklisted = true;
+                    }
+                }
+
+                if (validRecord)
+                    await transaction.CommitAsync();
+                else
+                    await transaction.RollbackAsync();
+
+                if (foundBlacklisted)
+                    return Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.OrganismBlacklisted });
+
+                return Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.Success });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Reporting: ReportPopulation failed");
+                return Results.Ok(new ReportPopulationResponse { ReturnCode = ReportingReturnCode.Success });
+            }
+        });
+
+        group.MapGet("/stats/species-list", async (
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var species = await connection.QueryAsync<SpeciesWithPopulation>(
+                    "TerrariumGrabSpeciesInfo",
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(species);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Reporting: GetSpeciesList failed");
+                return Results.Ok(Array.Empty<SpeciesWithPopulation>());
+            }
+        });
+
+        group.MapGet("/stats/latest", async (
+            string species,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var data = await connection.QueryAsync<SpeciesPopulationData>(
+                    "TerrariumGrabLatestSpeciesData",
+                    new { SpeciesName = species },
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Reporting: GrabLatestSpeciesData failed for {Species}", species);
+                return Results.Ok(Array.Empty<SpeciesPopulationData>());
+            }
+        });
+
+        group.MapGet("/stats/top-animals", async (
+            string version,
+            string type,
+            int? count,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            var num = count ?? 3;
+
+            try
+            {
+                var normalizedVersion = new Version(version).ToString(3);
+
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var animals = await connection.QueryAsync<TopAnimalEntry>(
+                    "TerrariumTopAnimals",
+                    new { Count = num, Version = normalizedVersion, SpeciesType = type },
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(animals);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Reporting: GetTopAnimals failed");
+                return Results.Ok(Array.Empty<TopAnimalEntry>());
+            }
+        });
+
+        return group;
+    }
+}

--- a/src/Terrarium.Server/SpeciesEndpoints.cs
+++ b/src/Terrarium.Server/SpeciesEndpoints.cs
@@ -1,0 +1,318 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using Terrarium.Server.Middleware;
+
+namespace Terrarium.Server;
+
+/// <summary>
+/// Return codes for species registration.
+/// Ported from Server/Website/App_Code/Species/AddSpecies.asmx.cs.
+/// </summary>
+public enum SpeciesServiceStatus
+{
+    Success,
+    AlreadyExists,
+    ServerDown,
+    VersionIncompatible,
+    FiveMinuteThrottle,
+    TwentyFourHourThrottle,
+    PoliCheckSpeciesNameFailure,
+    PoliCheckAuthorNameFailure,
+    PoliCheckEmailFailure
+}
+
+/// <summary>
+/// Request body for POST /api/species/register.
+/// </summary>
+public sealed class RegisterSpeciesRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string AssemblyFullName { get; set; } = string.Empty;
+    public byte[]? AssemblyCode { get; set; }
+}
+
+/// <summary>
+/// Response from POST /api/species/register.
+/// </summary>
+public sealed class RegisterSpeciesResponse
+{
+    public SpeciesServiceStatus Status { get; set; }
+}
+
+/// <summary>
+/// A species record returned from list/get queries.
+/// </summary>
+public sealed class SpeciesInfo
+{
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public string AuthorEmail { get; set; } = string.Empty;
+    public DateTime DateAdded { get; set; }
+    public string AssemblyFullName { get; set; } = string.Empty;
+    public byte Extinct { get; set; }
+    public DateTime? LastReintroduction { get; set; }
+    public Guid? ReintroductionNode { get; set; }
+    public string Version { get; set; } = string.Empty;
+    public bool BlackListed { get; set; }
+}
+
+/// <summary>
+/// Request body for POST /api/species/reintroduce.
+/// </summary>
+public sealed class ReintroduceSpeciesRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Version { get; set; } = string.Empty;
+    public Guid PeerGuid { get; set; }
+}
+
+/// <summary>
+/// Response from POST /api/species/reintroduce.
+/// </summary>
+public sealed class ReintroduceSpeciesResponse
+{
+    public bool Success { get; set; }
+    public byte[]? AssemblyCode { get; set; }
+}
+
+/// <summary>
+/// Minimal API endpoints for the Species service.
+/// Ported from Server/Website/App_Code/Species/AddSpecies.asmx.cs.
+/// </summary>
+public static class SpeciesEndpoints
+{
+    public static RouteGroupBuilder MapSpeciesEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/register", async (
+            RegisterSpeciesRequest request,
+            HttpContext httpContext,
+            IOptions<ServerSettings> settings,
+            ThrottleService throttle,
+            ILogger<Program> logger) =>
+        {
+            if (string.IsNullOrEmpty(request.Name) ||
+                string.IsNullOrEmpty(request.Version) ||
+                string.IsNullOrEmpty(request.Type) ||
+                string.IsNullOrEmpty(request.Author) ||
+                string.IsNullOrEmpty(request.Email) ||
+                string.IsNullOrEmpty(request.AssemblyFullName) ||
+                request.AssemblyCode is null or { Length: 0 })
+            {
+                return Results.Ok(new RegisterSpeciesResponse { Status = SpeciesServiceStatus.VersionIncompatible });
+            }
+
+            var version = new Version(request.Version).ToString(3);
+            var ipAddress = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+            // Check 5-minute throttle
+            if (throttle.IsThrottled(ipAddress, "AddSpecies5MinuteThrottle"))
+            {
+                return Results.Ok(new RegisterSpeciesResponse { Status = SpeciesServiceStatus.FiveMinuteThrottle });
+            }
+
+            // Check 24-hour throttle
+            if (throttle.IsThrottled(ipAddress, "AddSpecies24HourThrottle"))
+            {
+                return Results.Ok(new RegisterSpeciesResponse { Status = SpeciesServiceStatus.TwentyFourHourThrottle });
+            }
+
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var parameters = new DynamicParameters();
+                parameters.Add("@Name", request.Name, DbType.String, size: 255);
+                parameters.Add("@Version", version, DbType.String, size: 255);
+                parameters.Add("@Type", request.Type, DbType.String, size: 50);
+                parameters.Add("@Author", request.Author, DbType.String, size: 255);
+                parameters.Add("@AuthorEmail", request.Email, DbType.String, size: 255);
+                parameters.Add("@Extinct", (byte)0, DbType.Byte);
+                parameters.Add("@DateAdded", DateTime.UtcNow, DbType.DateTime);
+                parameters.Add("@AssemblyFullName", request.AssemblyFullName, DbType.String);
+                parameters.Add("@BlackListed", false, DbType.Boolean);
+
+                try
+                {
+                    await connection.ExecuteAsync(
+                        "TerrariumInsertSpecies",
+                        parameters,
+                        commandType: CommandType.StoredProcedure);
+                }
+                catch (SqlException ex) when (ex.Number == 2627)
+                {
+                    return Results.Ok(new RegisterSpeciesResponse { Status = SpeciesServiceStatus.AlreadyExists });
+                }
+
+                // Apply throttles after successful insert
+                var introductionWait = settings.Value.IntroductionWait;
+                throttle.AddThrottle(ipAddress, "AddSpecies5MinuteThrottle", 1, TimeSpan.FromMinutes(introductionWait));
+
+                var dailyLimit = settings.Value.IntroductionDailyLimit;
+                throttle.AddThrottle(ipAddress, "AddSpecies24HourThrottle", dailyLimit, TimeSpan.FromHours(24));
+
+                return Results.Ok(new RegisterSpeciesResponse { Status = SpeciesServiceStatus.Success });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Species: Register failed");
+                return Results.Ok(new RegisterSpeciesResponse { Status = SpeciesServiceStatus.ServerDown });
+            }
+        });
+
+        group.MapGet("/list", async (
+            string version,
+            string? filter,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            if (string.IsNullOrEmpty(version))
+            {
+                return Results.Ok(Array.Empty<SpeciesInfo>());
+            }
+
+            var normalizedVersion = new Version(version).ToString(3);
+            var sprocName = filter == "All"
+                ? "TerrariumGrabAllSpecies"
+                : "TerrariumGrabAllRecentSpecies";
+
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var species = await connection.QueryAsync<SpeciesInfo>(
+                    sprocName,
+                    new { Version = normalizedVersion },
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(species);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Species: List failed");
+                return Results.Ok(Array.Empty<SpeciesInfo>());
+            }
+        });
+
+        group.MapGet("/extinct", async (
+            string version,
+            string? filter,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            if (string.IsNullOrEmpty(version))
+            {
+                return Results.Ok(Array.Empty<SpeciesInfo>());
+            }
+
+            var normalizedVersion = new Version(version).ToString(3);
+            var sprocName = filter == "All"
+                ? "TerrariumGrabExtinctSpecies"
+                : "TerrariumGrabExtinctRecentSpecies";
+
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var species = await connection.QueryAsync<SpeciesInfo>(
+                    sprocName,
+                    new { Version = normalizedVersion },
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(species);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Species: GetExtinct failed");
+                return Results.Ok(Array.Empty<SpeciesInfo>());
+            }
+        });
+
+        group.MapGet("/blacklisted", async (
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var blacklisted = await connection.QueryAsync<string>(
+                    "SELECT AssemblyFullName FROM Species WHERE BlackListed = 1");
+
+                return Results.Ok(blacklisted);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Species: GetBlacklisted failed");
+                return Results.Ok(Array.Empty<string>());
+            }
+        });
+
+        group.MapPost("/reintroduce", async (
+            ReintroduceSpeciesRequest request,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            if (string.IsNullOrEmpty(request.Name) ||
+                string.IsNullOrEmpty(request.Version) ||
+                request.PeerGuid == Guid.Empty)
+            {
+                return Results.Ok(new ReintroduceSpeciesResponse { Success = false });
+            }
+
+            var version = new Version(request.Version).ToString(3);
+
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+                using var transaction = await connection.BeginTransactionAsync();
+
+                // Check if the species is extinct
+                var extinctCount = await connection.ExecuteScalarAsync<int?>(
+                    "TerrariumCheckSpeciesExtinct",
+                    new { Name = request.Name },
+                    transaction,
+                    commandType: CommandType.StoredProcedure);
+
+                if (extinctCount is null or 0)
+                {
+                    await transaction.RollbackAsync();
+                    return Results.Ok(new ReintroduceSpeciesResponse { Success = false });
+                }
+
+                // Mark species as reintroduced
+                await connection.ExecuteAsync(
+                    "TerrariumReintroduceSpecies",
+                    new
+                    {
+                        Name = request.Name,
+                        ReintroductionNode = request.PeerGuid,
+                        LastReintroduction = DateTime.UtcNow
+                    },
+                    transaction,
+                    commandType: CommandType.StoredProcedure);
+
+                await transaction.CommitAsync();
+                return Results.Ok(new ReintroduceSpeciesResponse { Success = true });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Species: Reintroduce failed for {Name}", request.Name);
+                return Results.Ok(new ReintroduceSpeciesResponse { Success = false });
+            }
+        });
+
+        return group;
+    }
+}


### PR DESCRIPTION
## Summary

Ports the Species registration and Reporting/Charts ASMX services to ASP.NET Core Minimal API endpoints backed by Dapper stored procedure calls.

### Species endpoints (#26)
- **POST /api/species/register** - Register a new creature species with throttling (5-min and 24-hour limits)
- **GET /api/species/list?version=&filter=** - List all species for a version (filter: All or recent)
- **GET /api/species/extinct?version=&filter=** - List extinct species available for reintroduction
- **GET /api/species/blacklisted** - Get assembly names of blacklisted species
- **POST /api/species/reintroduce** - Reintroduce an extinct species (transactional check-then-update)

### Reporting endpoints (#27)
- **POST /api/reporting/population** - Report population data per tick with blacklist checking, throttling, and anti-cheat validation
- **GET /api/reporting/stats/species-list** - Get all species with latest population data (via TerrariumGrabSpeciesInfo)
- **GET /api/reporting/stats/latest?species=** - Get latest population data point for a species
- **GET /api/reporting/stats/top-animals?version=&type=&count=** - Get top N animals by organism type

### Implementation notes
- Follows existing endpoint patterns established in Sprint 1 (MessagingEndpoints, PeerDiscoveryEndpoints, WatsonEndpoints)
- All stored procedure calls use Dapper DynamicParameters for output parameters
- Throttle enforcement via injected ThrottleService (matching legacy 5-min/24-hour/3-min windows)
- Anti-cheat: population bounds checking (max 600 total, max 340 per species, no negatives)
- Error handling returns safe defaults (empty arrays, Success codes) to match legacy behavior of not cascading errors to clients

Closes #26, Closes #27