### PR TITLE
Server: Charts, Usage endpoints + background worker

### DIFF
--- a/src/Terrarium.Server/ChartsEndpoints.cs
+++ b/src/Terrarium.Server/ChartsEndpoints.cs
@@ -1,0 +1,165 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+
+namespace Terrarium.Server;
+
+/// <summary>
+/// A population history data point for time-series charts.
+/// </summary>
+public sealed class PopulationHistoryEntry
+{
+    public DateTime SampleDateTime { get; set; }
+    public string SpeciesName { get; set; } = string.Empty;
+    public int Population { get; set; }
+    public int BirthCount { get; set; }
+    public int StarvedCount { get; set; }
+    public int KilledCount { get; set; }
+    public int ErrorCount { get; set; }
+    public int TimeoutCount { get; set; }
+    public int SickCount { get; set; }
+    public int OldAgeCount { get; set; }
+    public int SecurityViolationCount { get; set; }
+}
+
+/// <summary>
+/// A species distribution entry for pie charts.
+/// </summary>
+public sealed class SpeciesDistributionEntry
+{
+    public string SpeciesName { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string AuthorName { get; set; } = string.Empty;
+    public int Population { get; set; }
+}
+
+/// <summary>
+/// A top creature entry for leaderboard display.
+/// </summary>
+public sealed class TopCreatureEntry
+{
+    public string Name { get; set; } = string.Empty;
+    public string AuthorName { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public int Population { get; set; }
+    public int KilledCount { get; set; }
+}
+
+/// <summary>
+/// Minimal API endpoints for the Charts service.
+/// Ported from Server/Website/App_Code/Charts/ChartService.asmx.cs and ChartBuilder.cs.
+/// Provides ecosystem statistics data for dashboard charts.
+/// </summary>
+public static class ChartsEndpoints
+{
+    public static RouteGroupBuilder MapChartsEndpoints(this RouteGroupBuilder group)
+    {
+        // Population over time by species (for time-series chart)
+        group.MapGet("/population-history", async (
+            string species,
+            DateTime? beginDate,
+            DateTime? endDate,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                // If date range provided, use range query; otherwise grab latest
+                if (beginDate.HasValue && endDate.HasValue)
+                {
+                    var parameters = new DynamicParameters();
+                    parameters.Add("@SpeciesName", species, DbType.String, size: 50);
+                    parameters.Add("@BeginDate", beginDate.Value, DbType.DateTime);
+                    parameters.Add("@EndDate", endDate.Value, DbType.DateTime);
+
+                    var data = await connection.QueryAsync<PopulationHistoryEntry>(
+                        "TerrariumGrabSpeciesDataInDateRange",
+                        parameters,
+                        commandType: CommandType.StoredProcedure);
+
+                    return Results.Ok(data);
+                }
+                else
+                {
+                    var data = await connection.QueryAsync<PopulationHistoryEntry>(
+                        "TerrariumGrabLatestSpeciesData",
+                        new { SpeciesName = species },
+                        commandType: CommandType.StoredProcedure);
+
+                    return Results.Ok(data);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Charts: PopulationHistory failed for {Species}", species);
+                return Results.Ok(Array.Empty<PopulationHistoryEntry>());
+            }
+        });
+
+        // Current species distribution (for pie chart)
+        group.MapGet("/species-distribution", async (
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var data = await connection.QueryAsync<SpeciesDistributionEntry>(
+                    "TerrariumGrabSpeciesInfo",
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(data);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Charts: SpeciesDistribution failed");
+                return Results.Ok(Array.Empty<SpeciesDistributionEntry>());
+            }
+        });
+
+        // Top N creatures by population (for leaderboard)
+        group.MapGet("/top-creatures", async (
+            string version,
+            string? type,
+            int? count,
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            var num = count ?? 10;
+            var speciesType = type ?? "Animal";
+
+            try
+            {
+                var normalizedVersion = new Version(version).ToString(3);
+
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var parameters = new DynamicParameters();
+                parameters.Add("@Count", num, DbType.Int32);
+                parameters.Add("@Version", normalizedVersion, DbType.String, size: 25);
+                parameters.Add("@SpeciesType", speciesType, DbType.String, size: 50);
+
+                var animals = await connection.QueryAsync<TopCreatureEntry>(
+                    "TerrariumTopAnimals",
+                    parameters,
+                    commandType: CommandType.StoredProcedure);
+
+                return Results.Ok(animals);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Charts: TopCreatures failed");
+                return Results.Ok(Array.Empty<TopCreatureEntry>());
+            }
+        });
+
+        return group;
+    }
+}

--- a/src/Terrarium.Server/Program.cs
+++ b/src/Terrarium.Server/Program.cs
@@ -1,5 +1,6 @@
 using Terrarium.Server;
 using Terrarium.Server.Middleware;
+using Terrarium.Server.Workers;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,6 +9,7 @@ builder.Services.Configure<ServerSettings>(
     builder.Configuration.GetSection("Terrarium"));
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<ThrottleService>();
+builder.Services.AddHostedService<NonPageServicesWorker>();
 
 var app = builder.Build();
 
@@ -33,6 +35,12 @@ app.MapGroup("/api/species")
 
 app.MapGroup("/api/reporting")
     .MapReportingEndpoints();
+
+app.MapGroup("/api/charts")
+    .MapChartsEndpoints();
+
+app.MapGroup("/api/usage")
+    .MapUsageEndpoints();
 
 app.Run();
 

--- a/src/Terrarium.Server/UsageEndpoints.cs
+++ b/src/Terrarium.Server/UsageEndpoints.cs
@@ -1,0 +1,157 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+using Terrarium.Server.Middleware;
+
+namespace Terrarium.Server;
+
+/// <summary>
+/// Request body for POST /api/usage/heartbeat.
+/// </summary>
+public sealed class HeartbeatRequest
+{
+    public Guid Guid { get; set; }
+    public int CurrentTick { get; set; }
+}
+
+/// <summary>
+/// Response from POST /api/usage/heartbeat.
+/// </summary>
+public sealed class HeartbeatResponse
+{
+    public bool Success { get; set; }
+}
+
+/// <summary>
+/// Response from GET /api/usage/daily-stats.
+/// </summary>
+public sealed class DailyStatsResponse
+{
+    public int ActivePeers { get; set; }
+    public int SpeciesCount { get; set; }
+    public int TotalPopulation { get; set; }
+    public DateTime? LastRollup { get; set; }
+}
+
+/// <summary>
+/// Response from GET /api/usage/version-check.
+/// </summary>
+public sealed class ServerVersionResponse
+{
+    public string LatestVersion { get; set; } = string.Empty;
+    public string MOTD { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Minimal API endpoints for the Usage service.
+/// Ported from Server/Website/App_Code/UsageService.cs and related usage tracking.
+/// Provides heartbeat, daily statistics, and version info.
+/// </summary>
+public static class UsageEndpoints
+{
+    public static RouteGroupBuilder MapUsageEndpoints(this RouteGroupBuilder group)
+    {
+        // Client heartbeat (peer alive signal)
+        group.MapPost("/heartbeat", async (
+            HeartbeatRequest request,
+            HttpContext httpContext,
+            IOptions<ServerSettings> settings,
+            ThrottleService throttle,
+            ILogger<Program> logger) =>
+        {
+            if (request.Guid == Guid.Empty)
+            {
+                return Results.Ok(new HeartbeatResponse { Success = false });
+            }
+
+            var ipAddress = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+            // Throttle heartbeats to once per minute per peer
+            if (throttle.IsThrottled(ipAddress, "Heartbeat"))
+            {
+                return Results.Ok(new HeartbeatResponse { Success = true });
+            }
+
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                var parameters = new DynamicParameters();
+                parameters.Add("@Guid", request.Guid, DbType.Guid);
+                parameters.Add("@LastContact", DateTime.UtcNow, DbType.DateTime);
+                parameters.Add("@LastTick", request.CurrentTick, DbType.Int32);
+                parameters.Add("@ReturnCode", dbType: DbType.Int32, direction: ParameterDirection.Output);
+
+                await connection.ExecuteAsync(
+                    "TerrariumTimeoutReport",
+                    parameters,
+                    commandType: CommandType.StoredProcedure);
+
+                throttle.AddThrottle(ipAddress, "Heartbeat", 1, TimeSpan.FromMinutes(1));
+
+                return Results.Ok(new HeartbeatResponse { Success = true });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Usage: Heartbeat failed for {Guid}", request.Guid);
+                return Results.Ok(new HeartbeatResponse { Success = false });
+            }
+        });
+
+        // Daily active users, creature count, total ticks
+        group.MapGet("/daily-stats", async (
+            IOptions<ServerSettings> settings,
+            ILogger<Program> logger) =>
+        {
+            try
+            {
+                using var connection = new SqlConnection(settings.Value.SpeciesDsn);
+                await connection.OpenAsync();
+
+                // Count active peers from NodeLastContact (contacted in last 24 hours)
+                var activePeers = await connection.ExecuteScalarAsync<int>(
+                    "SELECT COUNT(*) FROM NodeLastContact WHERE LastContact > DATEADD(hh, -24, GETUTCDATE())");
+
+                // Count non-extinct, non-blacklisted species
+                var speciesCount = await connection.ExecuteScalarAsync<int>(
+                    "SELECT COUNT(*) FROM Species WHERE Extinct = 0 AND BlackListed = 0");
+
+                // Total population from latest rollup
+                var totalPopulation = await connection.ExecuteScalarAsync<int?>(
+                    @"SELECT SUM(Population) FROM DailyPopulation
+                      WHERE SampleDateTime = (SELECT MAX(SampleDateTime) FROM DailyPopulation)") ?? 0;
+
+                // Last rollup time
+                var lastRollup = await connection.ExecuteScalarAsync<DateTime?>(
+                    "SELECT MAX(SampleDateTime) FROM DailyPopulation");
+
+                return Results.Ok(new DailyStatsResponse
+                {
+                    ActivePeers = activePeers,
+                    SpeciesCount = speciesCount,
+                    TotalPopulation = totalPopulation,
+                    LastRollup = lastRollup
+                });
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Usage: DailyStats failed");
+                return Results.Ok(new DailyStatsResponse());
+            }
+        });
+
+        // Server version info for client compatibility
+        group.MapGet("/version-check", (IOptions<ServerSettings> settings) =>
+        {
+            return Results.Ok(new ServerVersionResponse
+            {
+                LatestVersion = settings.Value.LatestVersion,
+                MOTD = settings.Value.MOTD
+            });
+        });
+
+        return group;
+    }
+}

--- a/src/Terrarium.Server/Workers/NonPageServicesWorker.cs
+++ b/src/Terrarium.Server/Workers/NonPageServicesWorker.cs
@@ -1,0 +1,187 @@
+using System.Data;
+using Dapper;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
+
+namespace Terrarium.Server.Workers;
+
+/// <summary>
+/// Background worker that performs periodic maintenance tasks.
+/// Ported from Server/Website/App_Code/Code/NonPageServices.cs.
+///
+/// Tasks:
+/// - Stale peer cleanup: removes peers that haven't sent heartbeat in 5 minutes
+/// - Population snapshot: runs TerrariumAggregate to roll up History into DailyPopulation
+/// - Blacklist refresh: periodically reloads the species blacklist
+/// </summary>
+public sealed class NonPageServicesWorker : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<NonPageServicesWorker> _logger;
+
+    // Cached blacklist, refreshed periodically
+    private volatile HashSet<string> _blacklistedSpecies = [];
+
+    public NonPageServicesWorker(
+        IServiceProvider serviceProvider,
+        ILogger<NonPageServicesWorker> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the current set of blacklisted assembly names.
+    /// </summary>
+    public IReadOnlySet<string> BlacklistedSpecies => _blacklistedSpecies;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("NonPageServicesWorker starting");
+
+        // Initial blacklist load
+        await RefreshBlacklistAsync(stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var settings = _serviceProvider.GetRequiredService<IOptions<ServerSettings>>().Value;
+                var interval = TimeSpan.FromMilliseconds(settings.MillisecondsToRollupData);
+
+                await Task.Delay(interval, stoppingToken);
+
+                await CleanupStalePeersAsync(stoppingToken);
+                await RunPopulationSnapshotAsync(stoppingToken);
+                await RefreshBlacklistAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                // Graceful shutdown
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "NonPageServicesWorker: error during maintenance cycle");
+
+                // Wait a bit before retrying to avoid tight error loops
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }
+
+        _logger.LogInformation("NonPageServicesWorker stopped");
+    }
+
+    /// <summary>
+    /// Remove peers whose lease has expired (no heartbeat in 5 minutes).
+    /// Mirrors the peer expiration logic from TerrariumAggregate.
+    /// </summary>
+    private async Task CleanupStalePeersAsync(CancellationToken ct)
+    {
+        try
+        {
+            var settings = _serviceProvider.GetRequiredService<IOptions<ServerSettings>>().Value;
+            using var connection = new SqlConnection(settings.SpeciesDsn);
+            await connection.OpenAsync(ct);
+
+            // Move expired peers to ShutdownPeers and delete from Peers
+            var removed = await connection.ExecuteAsync(
+                @"INSERT INTO ShutdownPeers (Guid, Channel, IPAddress, FirstContact, LastContact, Version, UnRegister)
+                  SELECT Guid, Channel, IPAddress, FirstContact, GETUTCDATE(), Version, 0
+                  FROM Peers WHERE Lease < GETUTCDATE();
+
+                  DELETE FROM Peers WHERE Lease < GETUTCDATE();");
+
+            if (removed > 0)
+            {
+                _logger.LogInformation("NonPageServicesWorker: cleaned up {Count} stale peers", removed);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "NonPageServicesWorker: stale peer cleanup failed");
+        }
+    }
+
+    /// <summary>
+    /// Roll up History data into DailyPopulation snapshots via TerrariumAggregate.
+    /// This is the core data aggregation that powers the charts.
+    /// </summary>
+    private async Task RunPopulationSnapshotAsync(CancellationToken ct)
+    {
+        try
+        {
+            var settings = _serviceProvider.GetRequiredService<IOptions<ServerSettings>>().Value;
+            using var connection = new SqlConnection(settings.SpeciesDsn);
+            await connection.OpenAsync(ct);
+
+            var parameters = new DynamicParameters();
+            parameters.Add("@Expiration_Error", dbType: DbType.Int32, direction: ParameterDirection.Output);
+            parameters.Add("@Rollup_Error", dbType: DbType.Int32, direction: ParameterDirection.Output);
+            parameters.Add("@Timeout_Add_Error", dbType: DbType.Int32, direction: ParameterDirection.Output);
+            parameters.Add("@Timeout_Delete_Error", dbType: DbType.Int32, direction: ParameterDirection.Output);
+            parameters.Add("@Extinction_Error", dbType: DbType.Int32, direction: ParameterDirection.Output);
+
+            await connection.ExecuteAsync(
+                "TerrariumAggregate",
+                parameters,
+                commandTimeout: 120,
+                commandType: CommandType.StoredProcedure);
+
+            var expirationError = parameters.Get<int>("@Expiration_Error");
+            var rollupError = parameters.Get<int>("@Rollup_Error");
+            var timeoutAddError = parameters.Get<int>("@Timeout_Add_Error");
+            var timeoutDeleteError = parameters.Get<int>("@Timeout_Delete_Error");
+            var extinctionError = parameters.Get<int>("@Extinction_Error");
+
+            if (expirationError != 0 || rollupError != 0 || timeoutAddError != 0 ||
+                timeoutDeleteError != 0 || extinctionError != 0)
+            {
+                _logger.LogWarning(
+                    "NonPageServicesWorker: TerrariumAggregate completed with errors — " +
+                    "Expiration={Expiration}, Rollup={Rollup}, TimeoutAdd={TimeoutAdd}, " +
+                    "TimeoutDelete={TimeoutDelete}, Extinction={Extinction}",
+                    expirationError, rollupError, timeoutAddError, timeoutDeleteError, extinctionError);
+            }
+            else
+            {
+                _logger.LogInformation("NonPageServicesWorker: population snapshot completed successfully");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "NonPageServicesWorker: population snapshot failed");
+        }
+    }
+
+    /// <summary>
+    /// Reload the species blacklist from the database.
+    /// </summary>
+    private async Task RefreshBlacklistAsync(CancellationToken ct)
+    {
+        try
+        {
+            var settings = _serviceProvider.GetRequiredService<IOptions<ServerSettings>>().Value;
+            using var connection = new SqlConnection(settings.SpeciesDsn);
+            await connection.OpenAsync(ct);
+
+            var names = await connection.QueryAsync<string>(
+                "SELECT AssemblyFullName FROM Species WHERE BlackListed = 1");
+
+            _blacklistedSpecies = new HashSet<string>(names, StringComparer.OrdinalIgnoreCase);
+
+            _logger.LogDebug("NonPageServicesWorker: blacklist refreshed, {Count} entries", _blacklistedSpecies.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "NonPageServicesWorker: blacklist refresh failed");
+        }
+    }
+}


### PR DESCRIPTION
## Sprint 4: Server Completion

### Issues
- Closes #34 — Port Charts + Usage endpoints
- Closes #35 — Port NonPageServices background worker

### Changes
- **ChartsEndpoints.cs**: Population history (time-series), species distribution (pie chart), top creatures (leaderboard)
- **UsageEndpoints.cs**: Heartbeat (peer alive signal), daily stats, version check
- **Workers/NonPageServicesWorker.cs**: Stale peer cleanup, population snapshots via TerrariumAggregate, blacklist refresh
- **Program.cs**: Register new endpoint groups and hosted worker service