### PR TITLE
Sprite animation mapping + Canvas loader

### DIFF
--- a/src/Terrarium.Game/Rendering/SpriteMetadata.cs
+++ b/src/Terrarium.Game/Rendering/SpriteMetadata.cs
@@ -1,0 +1,141 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Terrarium.Game.Rendering;
+
+/// <summary>
+/// Pixel dimensions for small and large sprite variants.
+/// </summary>
+public sealed record FrameSizeInfo(
+    [property: JsonPropertyName("small")] int Small,
+    [property: JsonPropertyName("large")] int Large);
+
+/// <summary>
+/// Width and height of a sprite sheet image in pixels.
+/// </summary>
+public sealed record SheetDimensions(
+    [property: JsonPropertyName("width")] int Width,
+    [property: JsonPropertyName("height")] int Height);
+
+/// <summary>
+/// References to the BMP sprite sheet files for each size variant.
+/// </summary>
+public sealed record SpriteSheetRef(
+    [property: JsonPropertyName("small")] string? Small,
+    [property: JsonPropertyName("large")] string? Large);
+
+/// <summary>
+/// Sheet dimensions for each size variant.
+/// </summary>
+public sealed record SheetSizeInfo(
+    [property: JsonPropertyName("small")] SheetDimensions? Small,
+    [property: JsonPropertyName("large")] SheetDimensions? Large);
+
+/// <summary>
+/// A single animation sequence within a sprite sheet.
+/// </summary>
+public sealed record AnimationSequence(
+    [property: JsonPropertyName("row")] int Row,
+    [property: JsonPropertyName("startFrame")] int StartFrame,
+    [property: JsonPropertyName("frameCount")] int FrameCount,
+    [property: JsonPropertyName("frameDuration")] int FrameDuration,
+    [property: JsonPropertyName("loop")] bool Loop);
+
+/// <summary>
+/// All animation data for a single creature type.
+/// </summary>
+public sealed record CreatureAnimations(
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("spriteSheet")] SpriteSheetRef SpriteSheet,
+    [property: JsonPropertyName("sheetSize")] SheetSizeInfo SheetSize,
+    [property: JsonPropertyName("animations")] Dictionary<string, AnimationSequence> Animations);
+
+/// <summary>
+/// Root object for the animations.json metadata file.
+/// </summary>
+public sealed record SpriteAnimationData(
+    [property: JsonPropertyName("frameSize")] FrameSizeInfo FrameSize,
+    [property: JsonPropertyName("creatures")] Dictionary<string, CreatureAnimations> Creatures);
+
+/// <summary>
+/// Service that loads and queries sprite animation metadata from animations.json.
+/// </summary>
+public sealed class SpriteMetadata
+{
+    private readonly SpriteAnimationData _data;
+
+    private SpriteMetadata(SpriteAnimationData data)
+    {
+        _data = data;
+    }
+
+    /// <summary>
+    /// Loads sprite metadata from a JSON string.
+    /// </summary>
+    public static SpriteMetadata Load(string json)
+    {
+        var data = JsonSerializer.Deserialize<SpriteAnimationData>(json)
+            ?? throw new InvalidOperationException("Failed to deserialize sprite animation data.");
+        return new SpriteMetadata(data);
+    }
+
+    /// <summary>
+    /// Loads sprite metadata from a file path.
+    /// </summary>
+    public static async Task<SpriteMetadata> LoadFromFileAsync(string path)
+    {
+        var json = await File.ReadAllTextAsync(path);
+        return Load(json);
+    }
+
+    /// <summary>
+    /// Gets the root animation data.
+    /// </summary>
+    public SpriteAnimationData Data => _data;
+
+    /// <summary>
+    /// Gets all known creature family names.
+    /// </summary>
+    public IEnumerable<string> CreatureFamilies => _data.Creatures.Keys;
+
+    /// <summary>
+    /// Gets animation data for a creature family, or null if not found.
+    /// </summary>
+    public CreatureAnimations? GetCreature(string family)
+    {
+        return _data.Creatures.GetValueOrDefault(family.ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// Gets a specific animation sequence for a creature family and action.
+    /// </summary>
+    /// <param name="family">Creature family name (e.g., "ant", "spider").</param>
+    /// <param name="action">Animation action key (e.g., "moved_n", "attacked_se", "idle").</param>
+    /// <returns>The animation sequence, or null if not found.</returns>
+    public AnimationSequence? GetAnimation(string family, string action)
+    {
+        var creature = GetCreature(family);
+        return creature?.Animations.GetValueOrDefault(action.ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// Gets frame pixel coordinates for a specific frame within an animation.
+    /// </summary>
+    /// <param name="family">Creature family name.</param>
+    /// <param name="action">Animation action key.</param>
+    /// <param name="frameIndex">Zero-based frame index within the animation.</param>
+    /// <param name="useLarge">True to use 48px frames, false for 24px.</param>
+    /// <returns>Tuple of (x, y, width, height) in pixels, or null if not found.</returns>
+    public (int X, int Y, int Width, int Height)? GetFrameRect(
+        string family, string action, int frameIndex, bool useLarge = true)
+    {
+        var animation = GetAnimation(family, action);
+        if (animation is null)
+            return null;
+
+        var frameSize = useLarge ? _data.FrameSize.Large : _data.FrameSize.Small;
+        var frame = animation.StartFrame + (frameIndex % animation.FrameCount);
+
+        return (frame * frameSize, animation.Row * frameSize, frameSize, frameSize);
+    }
+}

--- a/src/Terrarium.Game/Terrarium.Game.csproj
+++ b/src/Terrarium.Game/Terrarium.Game.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.*" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Terrarium.OrganismBase\Terrarium.OrganismBase.csproj" />
   </ItemGroup>
 

--- a/src/Terrarium.Web/wwwroot/assets/sprites/animations.json
+++ b/src/Terrarium.Web/wwwroot/assets/sprites/animations.json
@@ -1,0 +1,1694 @@
+{
+  "frameSize": {
+    "small": 24,
+    "large": 48
+  },
+  "layout": {
+    "framesPerRow": 10,
+    "totalRows": 40,
+    "directions": [
+      "n",
+      "ne",
+      "e",
+      "se",
+      "s",
+      "sw",
+      "w",
+      "nw"
+    ],
+    "directionIndices": {
+      "n": 7,
+      "ne": 8,
+      "e": 1,
+      "se": 2,
+      "s": 3,
+      "sw": 4,
+      "w": 5,
+      "nw": 6
+    },
+    "actionBaseRows": {
+      "attacked": 0,
+      "defended": 8,
+      "died": 16,
+      "ate": 24,
+      "moved": 32
+    }
+  },
+  "creatures": {
+    "ant": {
+      "type": "animal",
+      "spriteSheet": {
+        "small": "ant24.bmp",
+        "large": "ant48.bmp"
+      },
+      "sheetSize": {
+        "small": {
+          "width": 240,
+          "height": 960
+        },
+        "large": {
+          "width": 480,
+          "height": 1920
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 1,
+          "frameDuration": 500,
+          "loop": false
+        },
+        "attacked_e": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_se": {
+          "row": 1,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_s": {
+          "row": 2,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_sw": {
+          "row": 3,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_w": {
+          "row": 4,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_nw": {
+          "row": 5,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_n": {
+          "row": 6,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_ne": {
+          "row": 7,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "defended_e": {
+          "row": 8,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_se": {
+          "row": 9,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_s": {
+          "row": 10,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_sw": {
+          "row": 11,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_w": {
+          "row": 12,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_nw": {
+          "row": 13,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_n": {
+          "row": 14,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_ne": {
+          "row": 15,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "died_e": {
+          "row": 16,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_se": {
+          "row": 17,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_s": {
+          "row": 18,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_sw": {
+          "row": 19,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_w": {
+          "row": 20,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_nw": {
+          "row": 21,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_n": {
+          "row": 22,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_ne": {
+          "row": 23,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "ate_e": {
+          "row": 24,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_se": {
+          "row": 25,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_s": {
+          "row": 26,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_sw": {
+          "row": 27,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_w": {
+          "row": 28,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_nw": {
+          "row": 29,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_n": {
+          "row": 30,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_ne": {
+          "row": 31,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "moved_e": {
+          "row": 32,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_se": {
+          "row": 33,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_s": {
+          "row": 34,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_sw": {
+          "row": 35,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_w": {
+          "row": 36,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_nw": {
+          "row": 37,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_n": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_ne": {
+          "row": 39,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        }
+      }
+    },
+    "beetle": {
+      "type": "animal",
+      "spriteSheet": {
+        "small": "beetle24.bmp",
+        "large": "beetle48.bmp"
+      },
+      "sheetSize": {
+        "small": {
+          "width": 240,
+          "height": 960
+        },
+        "large": {
+          "width": 480,
+          "height": 1920
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 1,
+          "frameDuration": 500,
+          "loop": false
+        },
+        "attacked_e": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_se": {
+          "row": 1,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_s": {
+          "row": 2,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_sw": {
+          "row": 3,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_w": {
+          "row": 4,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_nw": {
+          "row": 5,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_n": {
+          "row": 6,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_ne": {
+          "row": 7,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "defended_e": {
+          "row": 8,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_se": {
+          "row": 9,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_s": {
+          "row": 10,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_sw": {
+          "row": 11,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_w": {
+          "row": 12,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_nw": {
+          "row": 13,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_n": {
+          "row": 14,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_ne": {
+          "row": 15,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "died_e": {
+          "row": 16,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_se": {
+          "row": 17,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_s": {
+          "row": 18,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_sw": {
+          "row": 19,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_w": {
+          "row": 20,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_nw": {
+          "row": 21,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_n": {
+          "row": 22,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_ne": {
+          "row": 23,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "ate_e": {
+          "row": 24,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_se": {
+          "row": 25,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_s": {
+          "row": 26,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_sw": {
+          "row": 27,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_w": {
+          "row": 28,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_nw": {
+          "row": 29,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_n": {
+          "row": 30,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_ne": {
+          "row": 31,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "moved_e": {
+          "row": 32,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_se": {
+          "row": 33,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_s": {
+          "row": 34,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_sw": {
+          "row": 35,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_w": {
+          "row": 36,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_nw": {
+          "row": 37,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_n": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_ne": {
+          "row": 39,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        }
+      }
+    },
+    "spider": {
+      "type": "animal",
+      "spriteSheet": {
+        "small": "spider24.bmp",
+        "large": "spider48.bmp"
+      },
+      "sheetSize": {
+        "small": {
+          "width": 240,
+          "height": 960
+        },
+        "large": {
+          "width": 480,
+          "height": 1920
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 1,
+          "frameDuration": 500,
+          "loop": false
+        },
+        "attacked_e": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_se": {
+          "row": 1,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_s": {
+          "row": 2,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_sw": {
+          "row": 3,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_w": {
+          "row": 4,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_nw": {
+          "row": 5,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_n": {
+          "row": 6,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_ne": {
+          "row": 7,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "defended_e": {
+          "row": 8,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_se": {
+          "row": 9,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_s": {
+          "row": 10,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_sw": {
+          "row": 11,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_w": {
+          "row": 12,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_nw": {
+          "row": 13,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_n": {
+          "row": 14,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_ne": {
+          "row": 15,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "died_e": {
+          "row": 16,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_se": {
+          "row": 17,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_s": {
+          "row": 18,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_sw": {
+          "row": 19,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_w": {
+          "row": 20,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_nw": {
+          "row": 21,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_n": {
+          "row": 22,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_ne": {
+          "row": 23,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "ate_e": {
+          "row": 24,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_se": {
+          "row": 25,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_s": {
+          "row": 26,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_sw": {
+          "row": 27,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_w": {
+          "row": 28,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_nw": {
+          "row": 29,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_n": {
+          "row": 30,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_ne": {
+          "row": 31,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "moved_e": {
+          "row": 32,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_se": {
+          "row": 33,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_s": {
+          "row": 34,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_sw": {
+          "row": 35,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_w": {
+          "row": 36,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_nw": {
+          "row": 37,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_n": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_ne": {
+          "row": 39,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        }
+      }
+    },
+    "inchworm": {
+      "type": "animal",
+      "spriteSheet": {
+        "small": "inchworm24.bmp",
+        "large": "inchworm48.bmp"
+      },
+      "sheetSize": {
+        "small": {
+          "width": 240,
+          "height": 960
+        },
+        "large": {
+          "width": 480,
+          "height": 1920
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 1,
+          "frameDuration": 500,
+          "loop": false
+        },
+        "attacked_e": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_se": {
+          "row": 1,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_s": {
+          "row": 2,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_sw": {
+          "row": 3,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_w": {
+          "row": 4,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_nw": {
+          "row": 5,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_n": {
+          "row": 6,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_ne": {
+          "row": 7,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "defended_e": {
+          "row": 8,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_se": {
+          "row": 9,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_s": {
+          "row": 10,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_sw": {
+          "row": 11,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_w": {
+          "row": 12,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_nw": {
+          "row": 13,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_n": {
+          "row": 14,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_ne": {
+          "row": 15,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "died_e": {
+          "row": 16,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_se": {
+          "row": 17,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_s": {
+          "row": 18,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_sw": {
+          "row": 19,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_w": {
+          "row": 20,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_nw": {
+          "row": 21,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_n": {
+          "row": 22,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_ne": {
+          "row": 23,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "ate_e": {
+          "row": 24,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_se": {
+          "row": 25,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_s": {
+          "row": 26,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_sw": {
+          "row": 27,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_w": {
+          "row": 28,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_nw": {
+          "row": 29,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_n": {
+          "row": 30,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_ne": {
+          "row": 31,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "moved_e": {
+          "row": 32,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_se": {
+          "row": 33,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_s": {
+          "row": 34,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_sw": {
+          "row": 35,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_w": {
+          "row": 36,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_nw": {
+          "row": 37,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_n": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_ne": {
+          "row": 39,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        }
+      }
+    },
+    "scorpion": {
+      "type": "animal",
+      "spriteSheet": {
+        "small": "scorpion24.bmp",
+        "large": "scorpion48.bmp"
+      },
+      "sheetSize": {
+        "small": {
+          "width": 240,
+          "height": 960
+        },
+        "large": {
+          "width": 480,
+          "height": 1920
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 1,
+          "frameDuration": 500,
+          "loop": false
+        },
+        "attacked_e": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_se": {
+          "row": 1,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_s": {
+          "row": 2,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_sw": {
+          "row": 3,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_w": {
+          "row": 4,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_nw": {
+          "row": 5,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_n": {
+          "row": 6,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "attacked_ne": {
+          "row": 7,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 80,
+          "loop": false
+        },
+        "defended_e": {
+          "row": 8,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_se": {
+          "row": 9,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_s": {
+          "row": 10,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_sw": {
+          "row": 11,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_w": {
+          "row": 12,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_nw": {
+          "row": 13,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_n": {
+          "row": 14,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "defended_ne": {
+          "row": 15,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "died_e": {
+          "row": 16,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_se": {
+          "row": 17,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_s": {
+          "row": 18,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_sw": {
+          "row": 19,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_w": {
+          "row": 20,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_nw": {
+          "row": 21,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_n": {
+          "row": 22,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "died_ne": {
+          "row": 23,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 120,
+          "loop": false
+        },
+        "ate_e": {
+          "row": 24,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_se": {
+          "row": 25,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_s": {
+          "row": 26,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_sw": {
+          "row": 27,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_w": {
+          "row": 28,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_nw": {
+          "row": 29,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_n": {
+          "row": 30,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "ate_ne": {
+          "row": 31,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": false
+        },
+        "moved_e": {
+          "row": 32,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_se": {
+          "row": 33,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_s": {
+          "row": 34,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_sw": {
+          "row": 35,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_w": {
+          "row": 36,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_nw": {
+          "row": 37,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_n": {
+          "row": 38,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        },
+        "moved_ne": {
+          "row": 39,
+          "startFrame": 0,
+          "frameCount": 10,
+          "frameDuration": 100,
+          "loop": true
+        }
+      }
+    },
+    "plant": {
+      "type": "plant",
+      "spriteSheet": {
+        "small": "plant24.bmp",
+        "large": "plant48.bmp"
+      },
+      "sheetSize": {
+        "small": {
+          "width": 24,
+          "height": 24
+        },
+        "large": {
+          "width": 48,
+          "height": 48
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 1,
+          "frameDuration": 1000,
+          "loop": false
+        }
+      }
+    },
+    "plantone": {
+      "type": "plant",
+      "spriteSheet": {
+        "small": "plantone24.bmp",
+        "large": "plantone48.bmp"
+      },
+      "sheetSize": {
+        "small": {
+          "width": 24,
+          "height": 24
+        },
+        "large": {
+          "width": 48,
+          "height": 48
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 1,
+          "frameDuration": 1000,
+          "loop": false
+        }
+      }
+    },
+    "planttwo": {
+      "type": "plant",
+      "spriteSheet": {
+        "small": "planttwo24.bmp",
+        "large": "planttwo48.bmp"
+      },
+      "sheetSize": {
+        "small": {
+          "width": 24,
+          "height": 24
+        },
+        "large": {
+          "width": 48,
+          "height": 48
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 1,
+          "frameDuration": 1000,
+          "loop": false
+        }
+      }
+    },
+    "plantthree": {
+      "type": "plant",
+      "spriteSheet": {
+        "small": "plantthree24.bmp",
+        "large": "plantthree48.bmp"
+      },
+      "sheetSize": {
+        "small": {
+          "width": 24,
+          "height": 24
+        },
+        "large": {
+          "width": 48,
+          "height": 48
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 1,
+          "frameDuration": 1000,
+          "loop": false
+        }
+      }
+    },
+    "teleporter": {
+      "type": "effect",
+      "spriteSheet": {
+        "large": "teleporter.bmp"
+      },
+      "sheetSize": {
+        "large": {
+          "width": 768,
+          "height": 48
+        }
+      },
+      "animations": {
+        "idle": {
+          "row": 0,
+          "startFrame": 0,
+          "frameCount": 16,
+          "frameDuration": 60,
+          "loop": true
+        }
+      }
+    }
+  }
+}

--- a/src/Terrarium.Web/wwwroot/js/sprite-loader.js
+++ b/src/Terrarium.Web/wwwroot/js/sprite-loader.js
@@ -1,0 +1,129 @@
+/**
+ * Terrarium sprite sheet loader and Canvas renderer.
+ * Loads BMP sprite sheets and draws individual animation frames to HTML5 Canvas.
+ */
+
+const SpriteLoader = (() => {
+    const _cache = new Map();
+
+    /**
+     * Loads a BMP sprite sheet and caches it as an ImageBitmap.
+     * @param {string} url - URL of the BMP sprite sheet.
+     * @returns {Promise<ImageBitmap>} The loaded image bitmap.
+     */
+    async function loadSheet(url) {
+        if (_cache.has(url)) {
+            return _cache.get(url);
+        }
+
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Failed to load sprite sheet: ${url} (${response.status})`);
+        }
+
+        const blob = await response.blob();
+        const bitmap = await createImageBitmap(blob);
+        _cache.set(url, bitmap);
+        return bitmap;
+    }
+
+    /**
+     * Draws a specific frame from a sprite sheet onto a Canvas context.
+     * @param {CanvasRenderingContext2D} ctx - The canvas 2D rendering context.
+     * @param {ImageBitmap} sheet - The loaded sprite sheet bitmap.
+     * @param {number} frameX - Column index of the frame (0-based).
+     * @param {number} frameY - Row index of the frame (0-based).
+     * @param {number} frameSize - Width and height of each frame in pixels.
+     * @param {number} destX - Destination X coordinate on the canvas.
+     * @param {number} destY - Destination Y coordinate on the canvas.
+     * @param {number} [destSize] - Destination draw size (defaults to frameSize).
+     */
+    function drawFrame(ctx, sheet, frameX, frameY, frameSize, destX, destY, destSize) {
+        const sx = frameX * frameSize;
+        const sy = frameY * frameSize;
+        const ds = destSize ?? frameSize;
+
+        ctx.drawImage(sheet, sx, sy, frameSize, frameSize, destX, destY, ds, ds);
+    }
+
+    /**
+     * Draws an animation frame by action key using animation metadata.
+     * @param {CanvasRenderingContext2D} ctx - The canvas 2D rendering context.
+     * @param {ImageBitmap} sheet - The loaded sprite sheet bitmap.
+     * @param {object} animation - Animation sequence from animations.json.
+     * @param {number} frameIndex - Zero-based frame index within the animation.
+     * @param {number} frameSize - Pixel size of each frame (24 or 48).
+     * @param {number} destX - Destination X coordinate on the canvas.
+     * @param {number} destY - Destination Y coordinate on the canvas.
+     * @param {number} [destSize] - Destination draw size (defaults to frameSize).
+     */
+    function drawAnimationFrame(ctx, sheet, animation, frameIndex, frameSize, destX, destY, destSize) {
+        const frame = animation.startFrame + (frameIndex % animation.frameCount);
+        drawFrame(ctx, sheet, frame, animation.row, frameSize, destX, destY, destSize);
+    }
+
+    /**
+     * Loads the animations.json metadata file.
+     * @param {string} [url='/assets/sprites/animations.json'] - URL of the metadata file.
+     * @returns {Promise<object>} The parsed animation metadata.
+     */
+    async function loadMetadata(url) {
+        const metadataUrl = url ?? '/assets/sprites/animations.json';
+        const response = await fetch(metadataUrl);
+        if (!response.ok) {
+            throw new Error(`Failed to load sprite metadata: ${metadataUrl} (${response.status})`);
+        }
+        return response.json();
+    }
+
+    /**
+     * Preloads all sprite sheets for a set of creature families.
+     * @param {object} metadata - The animation metadata object.
+     * @param {string[]} families - Array of creature family names to preload.
+     * @param {boolean} [useLarge=true] - Whether to load large (48px) or small (24px) sheets.
+     * @param {string} [basePath='/assets/sprites/'] - Base URL path for sprite sheets.
+     * @returns {Promise<Map<string, ImageBitmap>>} Map of family name to loaded bitmap.
+     */
+    async function preloadSheets(metadata, families, useLarge, basePath) {
+        const base = basePath ?? '/assets/sprites/';
+        const large = useLarge ?? true;
+        const sheets = new Map();
+
+        const promises = families.map(async (family) => {
+            const creature = metadata.creatures[family];
+            if (!creature) return;
+
+            const file = large ? creature.spriteSheet.large : creature.spriteSheet.small;
+            if (!file) return;
+
+            const bitmap = await loadSheet(base + file);
+            sheets.set(family, bitmap);
+        });
+
+        await Promise.all(promises);
+        return sheets;
+    }
+
+    /**
+     * Clears the sprite sheet cache, releasing ImageBitmap resources.
+     */
+    function clearCache() {
+        for (const bitmap of _cache.values()) {
+            bitmap.close();
+        }
+        _cache.clear();
+    }
+
+    return {
+        loadSheet,
+        drawFrame,
+        drawAnimationFrame,
+        loadMetadata,
+        preloadSheets,
+        clearCache
+    };
+})();
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = SpriteLoader;
+}


### PR DESCRIPTION
## Sprint 4: Sprite Animation

### Issue
- Closes #36

### Changes
- **animations.json**: Complete frame-by-frame animation metadata for all 10 creatures (5 animals, 4 plants, teleporter) derived from actual BMP sprite sheet dimensions (240x960 / 480x1920 for animals = 10 frames x 40 rows)
- **SpriteMetadata.cs**: C# sprite animation lookup service with strongly-typed records (SpriteSheet, AnimationSequence, CreatureAnimations) and methods for frame rectangle calculation
- **sprite-loader.js**: Canvas-ready BMP sprite sheet renderer with ImageBitmap caching, per-frame drawing, and bulk preloading
- **Terrarium.Game.csproj**: Added Microsoft.Extensions.Logging.Abstractions package reference (fixes pre-existing build break)

### Sprite Sheet Layout (from legacy analysis)
- Animals: 10 columns x 40 rows (5 actions x 8 directions)
- Actions: attacked (rows 0-7), defended (8-15), died (16-23), ate (24-31), moved (32-39)
- Plants: single frame, no animation
- Teleporter: 16 frames x 1 row