### PR TITLE
Port GameEngine core — 10-phase tick loop, spatial index, movement physics

### DIFF
--- a/src/Terrarium.Game/AnimalSpecies.cs
+++ b/src/Terrarium.Game/AnimalSpecies.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Diagnostics;
+using System.Drawing;
+using System.Text;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Holds all species information about an animal.
+/// </summary>
+public sealed class AnimalSpecies : Species, IAnimalSpecies
+{
+    private readonly int _eatingSpeedPerUnitRadius;
+
+    public AnimalSpecies(Type clrType) : base(clrType)
+    {
+        SkinFamily = AnimalSkinFamily.Spider;
+        var totalPoints = 0;
+        Debug.Assert(clrType != null);
+        Debug.Assert(typeof(Animal).IsAssignableFrom(clrType));
+
+        var skinAttr = (AnimalSkinAttribute?)Attribute.GetCustomAttribute(clrType, typeof(AnimalSkinAttribute));
+        if (skinAttr != null) { SkinFamily = skinAttr.SkinFamily; Skin = skinAttr.Skin; }
+
+        var carnAttr = (CarnivoreAttribute?)Attribute.GetCustomAttribute(clrType, typeof(CarnivoreAttribute));
+        if (carnAttr == null) throw new GameEngineException("CarnivoreAttribute is required.");
+        IsCarnivore = carnAttr.IsCarnivore;
+
+        var eatAttr = (EatingSpeedPointsAttribute?)Attribute.GetCustomAttribute(clrType, typeof(EatingSpeedPointsAttribute));
+        if (eatAttr == null) throw new GameEngineException("EatingSpeedPointsAttribute is required.");
+        _eatingSpeedPerUnitRadius = eatAttr.EatingSpeedPerUnitRadius;
+        totalPoints += eatAttr.Points;
+
+        var atkAttr = (AttackDamagePointsAttribute?)Attribute.GetCustomAttribute(clrType, typeof(AttackDamagePointsAttribute));
+        if (atkAttr == null) throw new GameEngineException("AttackDamagePointsAttribute is required.");
+        MaximumAttackDamagePerUnitRadius = IsCarnivore
+            ? (int)(atkAttr.MaximumAttackDamagePerUnitRadius * EngineSettings.CarnivoreAttackDefendMultiplier)
+            : atkAttr.MaximumAttackDamagePerUnitRadius;
+        totalPoints += atkAttr.Points;
+
+        var defAttr = (DefendDamagePointsAttribute?)Attribute.GetCustomAttribute(clrType, typeof(DefendDamagePointsAttribute));
+        if (defAttr == null) throw new GameEngineException("DefendDamagePointsAttribute is required.");
+        MaximumDefendDamagePerUnitRadius = IsCarnivore
+            ? (int)(defAttr.MaximumDefendDamagePerUnitRadius * EngineSettings.CarnivoreAttackDefendMultiplier)
+            : defAttr.MaximumDefendDamagePerUnitRadius;
+        totalPoints += defAttr.Points;
+
+        var nrgAttr = (MaximumEnergyPointsAttribute?)Attribute.GetCustomAttribute(clrType, typeof(MaximumEnergyPointsAttribute));
+        if (nrgAttr == null) throw new GameEngineException("MaximumEnergyPointsAttribute is required.");
+        totalPoints += nrgAttr.Points;
+
+        var spdAttr = (MaximumSpeedPointsAttribute?)Attribute.GetCustomAttribute(clrType, typeof(MaximumSpeedPointsAttribute));
+        if (spdAttr == null) throw new GameEngineException("MaximumSpeedPointsAttribute is required.");
+        totalPoints += spdAttr.Points;
+        MaximumSpeed = spdAttr.MaximumSpeed;
+
+        var camAttr = (CamouflagePointsAttribute?)Attribute.GetCustomAttribute(clrType, typeof(CamouflagePointsAttribute));
+        if (camAttr == null) throw new GameEngineException("CamouflagePointsAttribute is required.");
+        totalPoints += camAttr.Points;
+        InvisibleOdds = camAttr.InvisibleOdds;
+
+        var eyeAttr = (EyesightPointsAttribute?)Attribute.GetCustomAttribute(clrType, typeof(EyesightPointsAttribute));
+        if (eyeAttr == null) throw new GameEngineException("EyesightPointsAttribute is required.");
+        totalPoints += eyeAttr.Points;
+        EyesightRadius = eyeAttr.EyesightRadius;
+
+        if (totalPoints > EngineSettings.MaxAvailableCharacteristicPoints) throw new TooManyPointsException();
+    }
+
+    public override int ReproductionWait => MatureRadius * EngineSettings.AnimalReproductionWaitPerUnitRadius;
+    public override int LifeSpan => IsCarnivore
+        ? MatureRadius * EngineSettings.AnimalLifeSpanPerUnitMaximumRadius * EngineSettings.CarnivoreLifeSpanMultiplier
+        : MatureRadius * EngineSettings.AnimalLifeSpanPerUnitMaximumRadius;
+
+    public bool IsCarnivore { get; private set; }
+    public int EatingSpeedPerUnitRadius => _eatingSpeedPerUnitRadius;
+    public AnimalSkinFamily SkinFamily { get; private set; }
+    public int MaximumAttackDamagePerUnitRadius { get; private set; }
+    public int MaximumDefendDamagePerUnitRadius { get; private set; }
+    public int MaximumSpeed { get; private set; }
+    public int InvisibleOdds { get; private set; }
+    public int EyesightRadius { get; private set; }
+
+    public override string GetAttributeWarnings()
+    {
+        var w = new StringBuilder();
+        w.Append(base.GetAttributeWarnings());
+        AppendWarning(w, Attribute.GetCustomAttribute(Type, typeof(EatingSpeedPointsAttribute)) as PointBasedCharacteristicAttribute);
+        AppendWarning(w, Attribute.GetCustomAttribute(Type, typeof(AttackDamagePointsAttribute)) as PointBasedCharacteristicAttribute);
+        AppendWarning(w, Attribute.GetCustomAttribute(Type, typeof(DefendDamagePointsAttribute)) as PointBasedCharacteristicAttribute);
+        AppendWarning(w, Attribute.GetCustomAttribute(Type, typeof(MaximumEnergyPointsAttribute)) as PointBasedCharacteristicAttribute);
+        AppendWarning(w, Attribute.GetCustomAttribute(Type, typeof(MaximumSpeedPointsAttribute)) as PointBasedCharacteristicAttribute);
+        AppendWarning(w, Attribute.GetCustomAttribute(Type, typeof(CamouflagePointsAttribute)) as PointBasedCharacteristicAttribute);
+        AppendWarning(w, Attribute.GetCustomAttribute(Type, typeof(EyesightPointsAttribute)) as PointBasedCharacteristicAttribute);
+        return w.ToString();
+    }
+
+    private static void AppendWarning(StringBuilder sb, PointBasedCharacteristicAttribute? attr)
+    {
+        if (attr == null) return;
+        var w = attr.GetWarnings();
+        if (w.Length != 0) { sb.Append(w); sb.Append(Environment.NewLine); }
+    }
+
+    public override OrganismState InitializeNewState(Point position, int generation)
+    {
+        var newState = new AnimalState(Guid.NewGuid().ToString(), this, generation, EnergyState.Hungry, InitialRadius)
+            { Position = position };
+        newState.ResetGrowthWait();
+        return newState;
+    }
+}

--- a/src/Terrarium.Game/AnimalWorldBoundary.cs
+++ b/src/Terrarium.Game/AnimalWorldBoundary.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Collections;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Animal-specific world boundary implementing IAnimalWorldBoundary.
+/// </summary>
+public class AnimalWorldBoundary : OrganismWorldBoundary, IAnimalWorldBoundary
+{
+    private readonly Func<WorldState> _currentStateAccessor;
+
+    internal AnimalWorldBoundary(
+        Organism animal, string id,
+        Func<WorldState> currentStateAccessor,
+        Func<int> worldWidthAccessor,
+        Func<int> worldHeightAccessor)
+        : base(animal, id, currentStateAccessor, worldWidthAccessor, worldHeightAccessor)
+    {
+        _currentStateAccessor = currentStateAccessor;
+    }
+
+    public AnimalState CurrentAnimalState
+        => (AnimalState)_currentStateAccessor().GetOrganismState(ID)!;
+
+    public ArrayList Scan()
+    {
+        var worldState = _currentStateAccessor();
+        var thisState = worldState.GetOrganismState(ID)!;
+        var found = worldState.FindOrganismsInView(CurrentAnimalState,
+            ((AnimalSpecies)thisState.Species).EyesightRadius);
+        var foundList = new ArrayList(found);
+        foundList.Remove(thisState);
+        for (var i = 0; i < foundList.Count;)
+        {
+            var state = (OrganismState)foundList[i]!;
+            if (state is AnimalState && state.IsAlive)
+            {
+                var invisible = Organism.OrganismRandom.Next(1, 100);
+                if (invisible <= ((AnimalSpecies)state.Species).InvisibleOdds)
+                {
+                    foundList.Remove(state);
+                    Organism.WriteTrace("#Camouflage hid animal from organism");
+                    continue;
+                }
+            }
+            i++;
+        }
+        return foundList;
+    }
+
+    public OrganismState? LookFor(OrganismState organismState)
+    {
+        if (organismState == null) throw new ArgumentNullException(nameof(organismState));
+        var target = LookForNoCamouflage(organismState);
+        if (target is AnimalState)
+        {
+            var inv = Organism.OrganismRandom.Next(1, 100);
+            if (inv <= ((AnimalSpecies)target.Species).InvisibleOdds)
+            {
+                Organism.WriteTrace("#Camouflage hid animal from organism");
+                return null;
+            }
+        }
+        return target;
+    }
+
+    public OrganismState? LookForNoCamouflage(OrganismState organismState)
+    {
+        if (organismState == null) return null;
+        var ws = _currentStateAccessor();
+        var os = ws.GetOrganismState(organismState.ID);
+        var thisOrg = CurrentAnimalState;
+        if (os == null || !thisOrg.IsWithinRect(((AnimalSpecies)thisOrg.Species).EyesightRadius, os))
+            return null;
+        return os;
+    }
+
+    public OrganismState? RefreshState(string organismID)
+    {
+        if (organismID == null) throw new ArgumentNullException(nameof(organismID));
+        var org = _currentStateAccessor().GetOrganismState(organismID);
+        if (org != null) org = LookFor(org);
+        return org;
+    }
+}

--- a/src/Terrarium.Game/GameEngine.cs
+++ b/src/Terrarium.Game/GameEngine.cs
@@ -1,0 +1,708 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Drawing;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using OrganismBase;
+using Terrarium.Configuration;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// The core Terrarium game engine. Controls creatures, updates world data,
+/// and manages all game events. The 10-phase ProcessTurn() method is the heart
+/// of the game loop.
+/// </summary>
+public class GameEngine
+{
+    private readonly ILogger<GameEngine> _logger;
+    private readonly Random _random = new(DateTime.Now.Millisecond);
+    private readonly ConcurrentQueue<object> _newOrganismQueue = new();
+    private readonly Queue<KilledOrganism> _removeOrganismQueue = new();
+
+    private int _maxAnimals = 50;
+    private int _maxPlants = 50;
+    private int _worldHeight = 2048;
+    private int _worldWidth = 2048;
+    private int _animalCount;
+    private int _plantCount;
+    private int _turnPhase;
+
+    private WorldVector? _currentVector;
+    private WorldState? _newWorldState;
+    private string[]? _organismIDList;
+    private PopulationData? _populationData;
+    private bool _ecosystemMode;
+
+    /// <summary>
+    /// Creates a new headless GameEngine.
+    /// </summary>
+    public GameEngine(
+        ILogger<GameEngine> logger,
+        PopulationData populationData,
+        int worldWidth = 2048,
+        int worldHeight = 2048,
+        int maxAnimals = 50,
+        int maxPlants = 50,
+        bool ecosystemMode = false)
+    {
+        _logger = logger;
+        _populationData = populationData;
+        _worldWidth = worldWidth;
+        _worldHeight = worldHeight;
+        _maxAnimals = maxAnimals;
+        _maxPlants = maxPlants;
+        _ecosystemMode = ecosystemMode;
+
+        EngineSettings.EngineSettingsAsserts();
+
+        // Normalize to grid cell boundaries
+        if (_worldWidth % EngineSettings.GridCellWidth != 0)
+            _worldWidth += EngineSettings.GridCellWidth - (_worldWidth % EngineSettings.GridCellWidth);
+        if (_worldHeight % EngineSettings.GridCellHeight != 0)
+            _worldHeight += EngineSettings.GridCellHeight - (_worldHeight % EngineSettings.GridCellHeight);
+
+        // Set up initial world state
+        var currentState = new WorldState(GridWidth, GridHeight);
+        currentState.TickNumber = 0;
+        currentState.StateGuid = Guid.NewGuid();
+        currentState.Teleporter = new Teleporter(_maxAnimals / EngineSettings.NumberOfAnimalsPerTeleporter);
+        currentState.MakeImmutable();
+
+        _currentVector = new WorldVector(currentState);
+
+        // TODO: Sprint 7 — create scheduler and set CurrentState
+        _logger.LogInformation("GameEngine initialized: {Width}x{Height}, max animals={Animals}, max plants={Plants}",
+            _worldWidth, _worldHeight, _maxAnimals, _maxPlants);
+    }
+
+    /// <summary>World height in pixels.</summary>
+    public int WorldHeight => _worldHeight;
+
+    /// <summary>World width in pixels.</summary>
+    public int WorldWidth => _worldWidth;
+
+    /// <summary>World width in grid cells.</summary>
+    public int GridWidth => _worldWidth >> EngineSettings.GridWidthPowerOfTwo;
+
+    /// <summary>World height in grid cells.</summary>
+    public int GridHeight => _worldHeight >> EngineSettings.GridHeightPowerOfTwo;
+
+    /// <summary>Max animal count.</summary>
+    public int MaxAnimals => _maxAnimals;
+
+    /// <summary>Max plant count.</summary>
+    public int MaxPlants => _maxPlants;
+
+    /// <summary>Current animal count.</summary>
+    public int AnimalCount => _animalCount;
+
+    /// <summary>Current plant count.</summary>
+    public int PlantCount => _plantCount;
+
+    /// <summary>Current turn phase (0-9).</summary>
+    public int TurnPhase => _turnPhase;
+
+    /// <summary>Whether in ecosystem mode.</summary>
+    public bool EcosystemMode => _ecosystemMode;
+
+    /// <summary>Population data tracker.</summary>
+    public PopulationData? PopulationData => _populationData;
+
+    /// <summary>The current world vector (state + actions).</summary>
+    public WorldVector? CurrentVector
+    {
+        get => _currentVector;
+        set
+        {
+            var oldVector = _currentVector;
+            _currentVector = value;
+            WorldVectorChanged?.Invoke(this, new WorldVectorChangedEventArgs(oldVector, _currentVector));
+        }
+    }
+
+    /// <summary>Fired when the world vector changes.</summary>
+    public event EventHandler<WorldVectorChangedEventArgs>? WorldVectorChanged;
+
+    /// <summary>Fired when engine state changes (for UI notifications).</summary>
+    public event EventHandler<EngineStateChangedEventArgs>? EngineStateChanged;
+
+    /// <summary>
+    /// Processes turns in a phase manner. After 10 calls, one game tick is complete.
+    /// </summary>
+    /// <returns>True if a complete tick has been processed.</returns>
+    public bool ProcessTurn()
+    {
+        // The 10-phase processing loop. Each phase is designed to take roughly
+        // equal time. The screen can be painted between phases for smooth frame rate.
+        // After all 10 phases, one game "tick" is complete.
+        switch (_turnPhase)
+        {
+            case 0:
+                // Phase 0: Save state if needed, give 1/5 of organisms time
+                if (_ecosystemMode && _populationData != null &&
+                    _populationData.IsReportingTick(CurrentVector!.State.TickNumber - 1))
+                {
+                    // TODO: Sprint 7 — serialize state via JSON
+                    _logger.LogDebug("State save point at tick {Tick}", CurrentVector.State.TickNumber);
+                }
+                // TODO: Sprint 7 — Scheduler.Tick()
+                break;
+
+            case 1:
+                // Phase 1: Give 1/5 of organisms time
+                // TODO: Sprint 7 — Scheduler.Tick()
+                break;
+
+            case 2:
+                // Phase 2: Give 1/5 of organisms time
+                // TODO: Sprint 7 — Scheduler.Tick()
+                break;
+
+            case 3:
+                // Phase 3: Give 1/5 of organisms time
+                // TODO: Sprint 7 — Scheduler.Tick()
+                break;
+
+            case 4:
+                // Phase 4: Give 1/5 of organisms time
+                // TODO: Sprint 7 — Scheduler.Tick()
+                break;
+
+            case 5:
+                // Phase 5: Gather actions, create mutable next state, remove queued organisms
+                var act = new TickActions();
+                // TODO: Sprint 7 — act.GatherActionsFromOrganisms(scheduler.Organisms)
+                CurrentVector!.Actions = act;
+
+                _newWorldState = CurrentVector.State.DuplicateMutable();
+                _newWorldState.TickNumber = _newWorldState.TickNumber + 1;
+                _populationData?.BeginTick(_newWorldState.TickNumber, CurrentVector.State.StateGuid);
+
+                RemoveOrganismsFromQueue();
+
+                _organismIDList = _newWorldState.OrganismIDs.ToArray();
+                KillDiseasedOrganisms();
+                break;
+
+            case 6:
+                // Phase 6: Burn energy, attacks, defends, movement vectors
+                Debug.Assert(_newWorldState != null, "Worldstate did not get created for this tick");
+                BurnBaseEnergy();
+                DoAttacks();
+                DoDefends();
+                ChangeMovementVectors();
+                break;
+
+            case 7:
+                // Phase 7: Move animals
+                MoveAnimals();
+                break;
+
+            case 8:
+                // Phase 8: Bites, growth, incubation, reproduction, healing
+                DoBites();
+                GrowAllOrganisms();
+                Incubate();
+                StartReproduction();
+                Heal();
+                break;
+
+            case 9:
+                // Phase 9: Plant energy, teleportation, insertions, antennas, finalize
+                GiveEnergyToPlants();
+                TeleportOrganisms();
+                InsertOrganismsFromQueue();
+                DoAntennas();
+
+                _newWorldState!.MakeImmutable();
+                var vector = new WorldVector(_newWorldState);
+                CurrentVector = vector;
+
+                // TODO: Sprint 7 — scheduler.CurrentState = _newWorldState
+                _populationData?.EndTick(_newWorldState.TickNumber);
+                _newWorldState = null;
+                break;
+        }
+
+        _turnPhase++;
+        if (_turnPhase == 10)
+        {
+            _turnPhase = 0;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Queues an organism for removal at the next safe point.
+    /// </summary>
+    public void RemoveOrganismQueued(KilledOrganism killedOrganism)
+    {
+        _removeOrganismQueue.Enqueue(killedOrganism);
+    }
+
+    /// <summary>
+    /// Adds a new organism to the insertion queue.
+    /// </summary>
+    public void AddNewOrganism(Species species, Point preferredLocation)
+    {
+        NewOrganism newOrganism;
+        if (preferredLocation == Point.Empty)
+        {
+            newOrganism = new NewOrganism(species.InitializeNewState(new Point(0, 0), 0), null);
+        }
+        else
+        {
+            newOrganism = new NewOrganism(species.InitializeNewState(preferredLocation, 0), null);
+            newOrganism.AddAtRandomLocation = false;
+        }
+        _newOrganismQueue.Enqueue(newOrganism);
+    }
+
+    /// <summary>
+    /// Stops the game and optionally serializes state.
+    /// </summary>
+    public void StopGame(bool serializeState)
+    {
+        if (serializeState)
+        {
+            // TODO: Sprint 7 — serialize state via System.Text.Json
+            _logger.LogInformation("Game state serialization requested");
+        }
+
+        _populationData?.Close();
+        _populationData = null;
+
+        // TODO: Sprint 7 — destroy scheduler
+        _logger.LogInformation("Game stopped");
+    }
+
+    #region Phase helper methods
+
+    private void ChangeMovementVectors()
+    {
+        foreach (var action in CurrentVector!.Actions.MoveToActions.Values)
+        {
+            var state = _newWorldState!.GetOrganismState(action.OrganismID);
+            if (state != null && state.IsAlive)
+                state.CurrentMoveToAction = action;
+        }
+    }
+
+    private void DoAntennas()
+    {
+        foreach (var orgState in _newWorldState!.Organisms)
+        {
+            if (orgState is not AnimalState animalState) continue;
+            // TODO: Sprint 7 — get Animal from scheduler, read antennas
+            var antennaState = new AntennaState((AntennaState?)null);
+            antennaState.MakeImmutable();
+            animalState.Antennas = antennaState;
+        }
+    }
+
+    private void DoDefends()
+    {
+        foreach (var action in CurrentVector!.Actions.DefendActions.Values)
+        {
+            var defenderState = _newWorldState!.GetOrganismState(action.OrganismID) as AnimalState;
+            if (defenderState != null && defenderState.IsAlive)
+                defenderState.OrganismEvents!.DefendCompleted = new DefendCompletedEventArgs(action.ActionID, action);
+        }
+    }
+
+    private void DoAttacks()
+    {
+        foreach (var action in CurrentVector!.Actions.AttackActions.Values)
+        {
+            var attackerState = _newWorldState!.GetOrganismState(action.OrganismID) as AnimalState;
+            if (attackerState == null || !attackerState.IsAlive) continue;
+
+            var defenderState = _newWorldState.GetOrganismState(action.TargetAnimal.ID) as AnimalState;
+            int damageCaused = 0;
+            bool escaped = false;
+            bool killed = false;
+
+            if (defenderState == null)
+            {
+                escaped = true;
+            }
+            else if (attackerState.IsWithinRect(1, defenderState))
+            {
+                if (defenderState.IsAlive)
+                {
+                    damageCaused = _random.Next(0, attackerState.AnimalSpecies.MaximumAttackDamagePerUnitRadius * attackerState.Radius);
+
+                    if (CurrentVector.Actions.DefendActions.TryGetValue(defenderState.ID, out var defendAction) &&
+                        defendAction.TargetAnimal.ID == attackerState.ID)
+                    {
+                        var defendDiscount = _random.Next(0,
+                            defenderState.AnimalSpecies.MaximumDefendDamagePerUnitRadius * defenderState.Radius);
+                        damageCaused = Math.Max(0, damageCaused - defendDiscount);
+                    }
+
+                    if (damageCaused > 0) defenderState.CauseDamage(damageCaused);
+                    killed = !defenderState.IsAlive;
+                    defenderState.OrganismEvents!.AttackedEvents.Add(new AttackedEventArgs(attackerState));
+                }
+            }
+
+            attackerState.OrganismEvents!.AttackCompleted =
+                new AttackCompletedEventArgs(action.ActionID, action, killed, escaped, damageCaused);
+        }
+    }
+
+    private void MoveAnimals()
+    {
+        _newWorldState!.Teleporter?.Move(WorldWidth, WorldHeight);
+
+        var index = new GridIndex();
+        foreach (var organismID in _organismIDList!)
+        {
+            var organismState = _newWorldState.GetOrganismState(organismID);
+            if (organismState == null) continue;
+
+            if (organismState is AnimalState animalState)
+            {
+                if (!animalState.IsStopped)
+                {
+                    var vector = Vector.Subtract(animalState.Position,
+                        animalState.CurrentMoveToAction!.MovementVector.Destination);
+                    Point newLocation;
+                    if (vector.Magnitude <= animalState.CurrentMoveToAction.MovementVector.Speed)
+                        newLocation = animalState.CurrentMoveToAction.MovementVector.Destination;
+                    else
+                    {
+                        var unitVector = vector.GetUnitVector();
+                        var speedVector = unitVector.Scale(animalState.CurrentMoveToAction.MovementVector.Speed);
+                        newLocation = Vector.Add(animalState.Position, speedVector);
+                    }
+                    index.AddPath(animalState, animalState.Position, newLocation, GridWidth, GridHeight);
+                }
+                else
+                    index.AddPath(animalState, animalState.Position, animalState.Position, GridWidth, GridHeight);
+            }
+            else
+                index.AddPath(organismState, organismState.Position, organismState.Position, GridWidth, GridHeight);
+        }
+
+        index.ResolvePaths();
+        _newWorldState.ClearIndex();
+
+        foreach (var segment in index.StartSegments)
+        {
+            if (segment.IsStationarySegment)
+            {
+                var stState = segment.State;
+                if (stState.CurrentMoveToAction != null)
+                {
+                    stState.OrganismEvents!.MoveCompleted =
+                        new MoveCompletedEventArgs(stState.CurrentMoveToAction.ActionID,
+                            stState.CurrentMoveToAction, ReasonForStop.DestinationReached, null);
+                    stState.CurrentMoveToAction = null;
+                }
+                continue;
+            }
+
+            var endSegment = segment;
+            while (endSegment.Next != null) endSegment = endSegment.Next;
+
+            var newState = (AnimalState)endSegment.State;
+            var moveVector = Vector.Subtract(endSegment.EndingPoint, endSegment.State.Position);
+            newState.Position = endSegment.EndingPoint;
+
+            Debug.Assert(endSegment.GridX == newState.GridX && endSegment.GridY == newState.GridY);
+            newState.BurnEnergy(newState.EnergyRequiredToMove(moveVector.Magnitude,
+                newState.CurrentMoveToAction!.MovementVector.Speed));
+
+            if (!newState.IsAlive) continue;
+
+            if (endSegment.ExitTime != 0)
+            {
+                newState.OrganismEvents!.MoveCompleted =
+                    new MoveCompletedEventArgs(newState.CurrentMoveToAction.ActionID,
+                        newState.CurrentMoveToAction, ReasonForStop.Blocked, endSegment.BlockedByState);
+                newState.CurrentMoveToAction = null;
+            }
+            else if (endSegment.State.CurrentMoveToAction!.MovementVector.Destination == newState.Position)
+            {
+                newState.OrganismEvents!.MoveCompleted =
+                    new MoveCompletedEventArgs(newState.CurrentMoveToAction.ActionID,
+                        newState.CurrentMoveToAction, ReasonForStop.DestinationReached, null);
+                newState.CurrentMoveToAction = null;
+            }
+        }
+
+        _newWorldState.BuildIndex();
+    }
+
+    private void GiveEnergyToPlants()
+    {
+        foreach (var organismID in _organismIDList!)
+        {
+            var organismState = _newWorldState!.GetOrganismState(organismID);
+            if (organismState is PlantState plantState && plantState.IsAlive)
+            {
+                var availableLight = CurrentVector!.State.GetAvailableLight(plantState);
+                plantState.GiveEnergy(availableLight);
+            }
+        }
+    }
+
+    private void TeleportOrganisms()
+    {
+        foreach (var organismID in _organismIDList!)
+        {
+            var organismState = _newWorldState!.GetOrganismState(organismID);
+            if (organismState == null) continue;
+            if (organismState is AnimalState && !organismState.IsAlive) continue;
+            if (_newWorldState.Teleporter != null && _newWorldState.Teleporter.IsInTeleporter(organismState))
+            {
+                // TODO: Sprint 7 — teleportation via network engine / Orleans
+                _logger.LogDebug("Organism {ID} in teleporter zone", organismID);
+            }
+        }
+    }
+
+    private void BurnBaseEnergy()
+    {
+        foreach (var organismID in _organismIDList!)
+        {
+            var state = _newWorldState!.GetOrganismState(organismID);
+            if (state == null || !state.IsAlive) continue;
+
+            if (state is AnimalState)
+                state.BurnEnergy(EngineSettings.BaseAnimalEnergyPerUnitOfRadius * state.Radius);
+            else
+                state.BurnEnergy(EngineSettings.BasePlantEnergyPerUnitOfRadius * state.Radius);
+        }
+    }
+
+    private void DoBites()
+    {
+        foreach (var action in CurrentVector!.Actions.EatActions.Values)
+        {
+            var eaterState = _newWorldState!.GetOrganismState(action.OrganismID) as AnimalState;
+            if (eaterState == null || !eaterState.IsAlive) continue;
+            // TODO: Sprint 7 — implement bite/eat logic
+        }
+    }
+
+    private void GrowAllOrganisms()
+    {
+        foreach (var organismID in _organismIDList!)
+        {
+            var state = _newWorldState!.GetOrganismState(organismID);
+            if (state == null || !state.IsAlive) continue;
+
+            var grownState = state.Grow();
+            if (grownState != state && _newWorldState.OnlyOverlapsSelf(grownState))
+                _newWorldState.RefreshOrganism(grownState);
+        }
+    }
+
+    private void Incubate()
+    {
+        foreach (var organismID in _organismIDList!)
+        {
+            var state = _newWorldState!.GetOrganismState(organismID);
+            if (state == null || !state.IsAlive || !state.IsIncubating) continue;
+
+            if (state.IncubationTicks == EngineSettings.TicksToIncubate)
+            {
+                var newPosition = FindEmptyPosition(state.CellRadius, Point.Empty);
+                if (newPosition != Point.Empty)
+                {
+                    var newOrganism = new NewOrganism(
+                        ((Species)state.Species).InitializeNewState(newPosition, state.Generation + 1),
+                        state.CurrentReproduceAction?.Dna != null
+                            ? (byte[])state.CurrentReproduceAction.Dna.Clone()
+                            : Array.Empty<byte>());
+                    _newOrganismQueue.Enqueue(newOrganism);
+                }
+
+                state.OrganismEvents!.ReproduceCompleted =
+                    new ReproduceCompletedEventArgs(state.CurrentReproduceAction!.ActionID,
+                        state.CurrentReproduceAction);
+                state.ResetReproductionWait();
+                state.CurrentReproduceAction = null;
+            }
+            else if (state.EnergyState >= EnergyState.Normal)
+            {
+                if (state is AnimalState)
+                    state.BurnEnergy(state.Radius * EngineSettings.AnimalIncubationEnergyPerUnitOfRadius);
+                else
+                    state.BurnEnergy(state.Radius * EngineSettings.PlantIncubationEnergyPerUnitOfRadius);
+                state.AddIncubationTick();
+            }
+        }
+    }
+
+    private void StartReproduction()
+    {
+        foreach (var action in CurrentVector!.Actions.ReproduceActions.Values)
+        {
+            var state = _newWorldState!.GetOrganismState(action.OrganismID);
+            if (state == null || !state.IsAlive) continue;
+            // TODO: Sprint 7 — implement reproduction logic
+        }
+    }
+
+    private void Heal()
+    {
+        foreach (var organismID in _organismIDList!)
+        {
+            var state = _newWorldState!.GetOrganismState(organismID);
+            if (state == null || !state.IsAlive) continue;
+            state.HealDamage();
+        }
+    }
+
+    private void KillDiseasedOrganisms()
+    {
+        if (_plantCount <= _maxPlants && _animalCount <= _maxAnimals) return;
+
+        // Kill excess organisms - oldest first for population control
+        foreach (var organismID in _organismIDList!)
+        {
+            var state = _newWorldState!.GetOrganismState(organismID);
+            if (state == null) continue;
+
+            if (state is PlantState && _plantCount > _maxPlants)
+            {
+                RemoveOrganism(new KilledOrganism(state.ID, PopulationChangeReason.Sick));
+                continue;
+            }
+
+            if (state is AnimalState && state.IsAlive && _animalCount > _maxAnimals)
+            {
+                state.Kill(PopulationChangeReason.Sick);
+            }
+        }
+    }
+
+    private void InsertOrganismsFromQueue()
+    {
+        while (_newOrganismQueue.TryDequeue(out var queueObject))
+        {
+            if (queueObject is NewOrganism newOrganism)
+            {
+                var organismState = newOrganism.State;
+                var newPosition = FindEmptyPosition(organismState.CellRadius,
+                    newOrganism.AddAtRandomLocation ? Point.Empty :
+                        new Point(organismState.Position.X >> EngineSettings.GridWidthPowerOfTwo,
+                            organismState.Position.Y >> EngineSettings.GridHeightPowerOfTwo));
+
+                if (newPosition != Point.Empty)
+                {
+                    organismState.Position = newPosition;
+                }
+                else
+                {
+                    OnEngineStateChanged(new EngineStateChangedEventArgs(
+                        $"A '{((Species)organismState.Species).Name}' died at birth: not enough space."));
+                    continue;
+                }
+
+                // TODO: Sprint 7 — scheduler.Create(species.Type, organismState.ID)
+                _newWorldState!.AddOrganism(organismState);
+                organismState.OrganismEvents!.Born = new BornEventArgs(newOrganism.Dna);
+                CountOrganism(organismState, PopulationChangeReason.Born);
+            }
+            // TODO: Sprint 7 — handle TeleportState objects
+        }
+    }
+
+    private void RemoveOrganismsFromQueue()
+    {
+        while (_removeOrganismQueue.Count > 0)
+            RemoveOrganism(_removeOrganismQueue.Dequeue());
+    }
+
+    private void RemoveOrganism(KilledOrganism killedOrganism)
+    {
+        var killedState = _newWorldState!.GetOrganismState(killedOrganism.ID);
+        if (killedState == null) return;
+
+        if (killedOrganism.DeathReason == PopulationChangeReason.Error &&
+            string.IsNullOrEmpty(killedOrganism.ExtraInformation))
+        {
+            killedState.Kill(killedOrganism.DeathReason);
+        }
+        else
+        {
+            UncountOrganism(killedState, killedOrganism.DeathReason);
+            // TODO: Sprint 7 — Scheduler.Remove(killedOrganism.ID)
+            _newWorldState.RemoveOrganism(killedOrganism.ID);
+        }
+    }
+
+    private void CountOrganism(OrganismState state, PopulationChangeReason reason)
+    {
+        Debug.Assert(state != null);
+        _populationData?.CountOrganism(((Species)state.Species).Name, reason);
+        if (state is AnimalState) _animalCount++;
+        else _plantCount++;
+    }
+
+    private void UncountOrganism(OrganismState state, PopulationChangeReason reason)
+    {
+        Debug.Assert(state != null);
+        _populationData?.UncountOrganism(((Species)state.Species).Name, reason);
+        if (state is AnimalState) _animalCount--;
+        else _plantCount--;
+    }
+
+    private Point FindEmptyPosition(int cellRadius, Point preferredGridPoint)
+    {
+        var newLocation = preferredGridPoint == Point.Empty
+            ? new Point(_random.Next(cellRadius, GridWidth - 1 - cellRadius),
+                _random.Next(cellRadius, GridHeight - 1 - cellRadius))
+            : preferredGridPoint;
+
+        var retry = 20;
+        while (retry > 0 &&
+            _newWorldState!.FindOrganismsInCells(
+                newLocation.X - cellRadius, newLocation.X + cellRadius,
+                newLocation.Y - cellRadius, newLocation.Y + cellRadius).Count != 0)
+        {
+            newLocation = new Point(
+                _random.Next(cellRadius, GridWidth - 1 - cellRadius),
+                _random.Next(cellRadius, GridHeight - 1 - cellRadius));
+            retry--;
+        }
+
+        return retry == 0
+            ? Point.Empty
+            : new Point(newLocation.X << EngineSettings.GridWidthPowerOfTwo,
+                newLocation.Y << EngineSettings.GridHeightPowerOfTwo);
+    }
+
+    private void OnEngineStateChanged(EngineStateChangedEventArgs e)
+    {
+        _logger.LogDebug("Engine state changed: {Message}", e.Message);
+        EngineStateChanged?.Invoke(this, e);
+    }
+
+    #endregion
+}
+
+/// <summary>Event args for world vector changes.</summary>
+public class WorldVectorChangedEventArgs : EventArgs
+{
+    public WorldVectorChangedEventArgs(WorldVector? oldVector, WorldVector? newVector)
+    { OldVector = oldVector; NewVector = newVector; }
+    public WorldVector? OldVector { get; }
+    public WorldVector? NewVector { get; }
+}
+
+/// <summary>Event args for engine state changes.</summary>
+public class EngineStateChangedEventArgs : EventArgs
+{
+    public EngineStateChangedEventArgs(string message)
+    { Message = message; }
+    public string Message { get; }
+}

--- a/src/Terrarium.Game/GridIndex.cs
+++ b/src/Terrarium.Game/GridIndex.cs
@@ -1,0 +1,204 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Diagnostics;
+using System.Drawing;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Implements the movement/collision algorithm for the Terrarium.
+/// Breaks creature paths into cell-based MovementSegments, then resolves
+/// conflicts when multiple creatures try to occupy the same cell.
+/// </summary>
+internal class GridIndex
+{
+    private const int TimeWindow = 10000;
+    private readonly Dictionary<int, List<SegmentWrapper>> _gridSquares = new();
+    private readonly List<SegmentWrapper> _sortedList = new(300);
+
+    public GridIndex()
+    {
+        StartSegments = new List<MovementSegment>(300);
+    }
+
+    public List<MovementSegment> StartSegments { get; private set; }
+
+    internal void ResolvePaths()
+    {
+        _sortedList.Sort(new SegmentWrapperComparer());
+        foreach (var wrapper in _sortedList)
+        {
+            var segment = wrapper.Segment;
+            var list = wrapper.ParentList;
+            Debug.Assert(list.Count >= 1);
+            if (segment.IsResolved)
+            {
+                Debug.Assert(segment.IsStartingSegment || segment.IsClipped);
+                continue;
+            }
+            if (segment.IsStartingSegment) { segment.CellsLeftToResolve = 0; }
+            else if (list.Count == 1) { segment.CellsLeftToResolve--; continue; }
+            else
+            {
+                foreach (var tw in list)
+                {
+                    var ts = tw.Segment;
+                    if (ts.State == segment.State) continue;
+                    if (!ts.Active) continue;
+                    segment.ClipSegment(ts.State);
+                    break;
+                }
+                segment.CellsLeftToResolve--;
+            }
+        }
+    }
+
+    public void AddPath(OrganismState state, Point p1, Point p2, int gridWidth, int gridHeight)
+    {
+        var x0 = p1.X; var y0 = p1.Y; var x1 = p2.X; var y1 = p2.Y;
+        var dy = y1 - y0; var dx = x1 - x0;
+        int stepx, stepy; var timeslice = 0;
+        Debug.Assert(x0 > -1 && x1 > -1 && y0 > -1 && y1 > -1);
+        if (dy < 0) { dy = -dy; stepy = -1; } else { stepy = 1; }
+        if (dx < 0) { dx = -dx; stepx = -1; } else { stepx = 1; }
+        dy <<= 1; dx <<= 1;
+        var gridX = x0 >> EngineSettings.GridWidthPowerOfTwo;
+        var gridY = y0 >> EngineSettings.GridWidthPowerOfTwo;
+        Debug.Assert(gridX == state.GridX && gridY == state.GridY);
+        var segment = new MovementSegment(null, state, new Point(x0, y0), 0, gridX, gridY)
+            { EndingPoint = new Point(p1.X, p1.Y) };
+        AddSegment(segment, gridWidth, gridHeight);
+        if (p1 == p2) return;
+
+        if (dx > dy)
+        {
+            if ((x1 - x0) != 0)
+            {
+                Debug.Assert((x1 - x0) < TimeWindow);
+                timeslice = TimeWindow / ((x1 - x0) * stepx);
+                Debug.Assert(timeslice != 0);
+            }
+            var fraction = dy - (dx >> 1);
+            while (x0 != x1)
+            {
+                if (fraction >= 0) { y0 += stepy; fraction -= dx; }
+                x0 += stepx; fraction += dy;
+                gridX = x0 >> EngineSettings.GridWidthPowerOfTwo;
+                gridY = y0 >> EngineSettings.GridHeightPowerOfTwo;
+                segment.ExitTime += timeslice;
+                if (gridX != segment.GridX || gridY != segment.GridY)
+                {
+                    var last = segment;
+                    segment = new MovementSegment(last, state, new Point(x0, y0), last.ExitTime, gridX, gridY)
+                        { ExitTime = last.ExitTime };
+                    last.Next = segment;
+                    AddSegment(segment, gridWidth, gridHeight);
+                }
+                segment.EndingPoint = new Point(x0, y0);
+            }
+        }
+        else
+        {
+            if ((y1 - y0) != 0)
+            {
+                Debug.Assert((y1 - y0) < TimeWindow);
+                timeslice = TimeWindow / ((y1 - y0) * stepy);
+                Debug.Assert(timeslice != 0);
+            }
+            var fraction = dx - (dy >> 1);
+            while (y0 != y1)
+            {
+                if (fraction >= 0) { x0 += stepx; fraction -= dy; }
+                y0 += stepy; fraction += dx;
+                gridX = x0 >> EngineSettings.GridWidthPowerOfTwo;
+                gridY = y0 >> EngineSettings.GridHeightPowerOfTwo;
+                segment.ExitTime += timeslice;
+                if (gridX != segment.GridX || gridY != segment.GridY)
+                {
+                    var last = segment;
+                    segment = new MovementSegment(last, state, new Point(x0, y0), last.ExitTime, gridX, gridY)
+                        { ExitTime = last.ExitTime };
+                    last.Next = segment;
+                    AddSegment(segment, gridWidth, gridHeight);
+                }
+                segment.EndingPoint = new Point(x0, y0);
+            }
+        }
+        segment.ExitTime = 0;
+    }
+
+    internal void AddSegment(MovementSegment segment, int gridWidth, int gridHeight)
+    {
+        var cellRadius = segment.State.CellRadius;
+        if (segment.Previous == null)
+        {
+            Debug.Assert(segment.GridX >= 0 && segment.GridY >= 0 &&
+                segment.GridX - cellRadius >= 0 && segment.GridY - cellRadius >= 0 &&
+                segment.GridX + cellRadius < gridWidth && segment.GridY + cellRadius < gridHeight);
+            Debug.Assert(segment.EntryTime == 0);
+            StartSegments.Add(segment);
+        }
+        else
+        {
+            Debug.Assert(segment.EntryTime != 0);
+            if (segment.GridX < 0 || segment.GridY < 0 ||
+                segment.GridX - cellRadius < 0 || segment.GridY - cellRadius < 0 ||
+                segment.GridX + cellRadius > gridWidth - 1 || segment.GridY + cellRadius > gridHeight - 1)
+            {
+                segment.Previous.Next = null;
+                return;
+            }
+        }
+        for (var x = segment.GridX - cellRadius; x <= segment.GridX + cellRadius; x++)
+        {
+            AddWrapperToCell(segment, x, segment.GridY - cellRadius);
+            AddWrapperToCell(segment, x, segment.GridY + cellRadius);
+        }
+        for (var y = segment.GridY - cellRadius + 1; y <= segment.GridY + cellRadius - 1; y++)
+        {
+            AddWrapperToCell(segment, segment.GridX - cellRadius, y);
+            AddWrapperToCell(segment, segment.GridX + cellRadius, y);
+        }
+    }
+
+    private void AddWrapperToCell(MovementSegment segment, int x, int y)
+    {
+        var hash = (x << 16) | y;
+        if (!_gridSquares.TryGetValue(hash, out var list))
+        {
+            list = new List<SegmentWrapper>();
+            _gridSquares[hash] = list;
+        }
+        Debug.Assert(segment.EntryTime != 0 || !HasStartingSegments(list));
+        var wrapper = new SegmentWrapper(segment, list);
+        list.Add(wrapper);
+        _sortedList.Add(wrapper);
+        segment.CellsLeftToResolve++;
+    }
+
+    internal static bool HasStartingSegments(List<SegmentWrapper> list)
+    {
+        foreach (var w in list)
+            if (w.Segment.EntryTime == 0) return true;
+        return false;
+    }
+
+    public class SegmentWrapper
+    {
+        public SegmentWrapper(MovementSegment segment, List<SegmentWrapper> parentList)
+        { Segment = segment; ParentList = parentList; }
+        public MovementSegment Segment { get; set; }
+        public List<SegmentWrapper> ParentList { get; set; }
+    }
+
+    private class SegmentWrapperComparer : IComparer<SegmentWrapper>
+    {
+        public int Compare(SegmentWrapper? x, SegmentWrapper? y)
+        {
+            if (x == null || y == null) return 0;
+            var diff = x.Segment.EntryTime - y.Segment.EntryTime;
+            return diff == 0 ? x.Segment.State.GetHashCode() - y.Segment.State.GetHashCode() : diff;
+        }
+    }
+}

--- a/src/Terrarium.Game/KilledOrganism.cs
+++ b/src/Terrarium.Game/KilledOrganism.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Represents an organism that has been killed and is pending removal.
+/// </summary>
+public class KilledOrganism
+{
+    public KilledOrganism(string id, PopulationChangeReason reason, string extraInformation)
+    { ID = id; DeathReason = reason; ExtraInformation = extraInformation; }
+
+    public KilledOrganism(string id, PopulationChangeReason reason)
+    { ID = id; DeathReason = reason; ExtraInformation = ""; }
+
+    public KilledOrganism(OrganismState state)
+    { ID = state.ID; DeathReason = state.DeathReason; ExtraInformation = ""; }
+
+    public string ID { get; private set; }
+    public string ExtraInformation { get; private set; }
+    public PopulationChangeReason DeathReason { get; private set; }
+}

--- a/src/Terrarium.Game/MovementSegment.cs
+++ b/src/Terrarium.Game/MovementSegment.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Diagnostics;
+using System.Drawing;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Tracks a segment of a creature's movement path through a single grid cell.
+/// </summary>
+internal class MovementSegment
+{
+    private bool _active;
+    private int _cellsLeftToResolve;
+
+    internal MovementSegment(
+        MovementSegment? previous, OrganismState state,
+        Point startingPoint, int entryTime, int gridX, int gridY)
+    {
+        Debug.Assert((previous == null && entryTime == 0) || (previous != null && entryTime != 0));
+        State = state;
+        StartingPoint = startingPoint;
+        EntryTime = entryTime;
+        GridX = gridX;
+        GridY = gridY;
+        Previous = previous;
+    }
+
+    public int CellsLeftToResolve
+    {
+        get => _cellsLeftToResolve;
+        set
+        {
+            if (value == 0)
+            {
+                if (!IsClipped)
+                {
+                    Active = true;
+                    if (Previous != null)
+                    {
+                        Debug.Assert(Previous.Active);
+                        Previous.Active = false;
+                    }
+                }
+            }
+            else if (value < 0) value = 0;
+            _cellsLeftToResolve = value;
+        }
+    }
+
+    public bool IsResolved
+    {
+        get => CellsLeftToResolve == 0;
+        set
+        {
+            if (value) CellsLeftToResolve = 0;
+            else throw new InvalidOperationException("Should never get unresolved");
+        }
+    }
+
+    public Point StartingPoint { get; set; }
+    public Point EndingPoint { get; set; }
+    public int GridX { get; set; }
+    public int GridY { get; set; }
+    public int EntryTime { get; set; }
+    public int ExitTime { get; set; }
+    public OrganismState State { get; set; }
+    public MovementSegment? Previous { get; set; }
+    public MovementSegment? Next { get; set; }
+    public OrganismState? BlockedByState { get; set; }
+
+    internal bool Active
+    {
+        get => _active;
+        set
+        {
+            Debug.Assert((value && !IsClipped) | !value);
+            _active = value;
+        }
+    }
+
+    internal bool IsStationarySegment
+        => StartingPoint == EndingPoint && EntryTime == 0 && ExitTime == 0;
+
+    internal bool IsClipped
+        => EntryTime != 0 && Previous?.Next == null;
+
+    internal bool IsStartingSegment => EntryTime == 0;
+
+    public override string ToString()
+        => $"{GridX}, {GridY}EntryTime={EntryTime}ExitTime={ExitTime}StartingPoint={StartingPoint}EndingPoint={EndingPoint}";
+
+    public void ClipSegment(OrganismState blocker)
+    {
+        MovementSegment? segment = this;
+        Debug.Assert(segment.Previous != null);
+        segment.Previous!.BlockedByState = blocker;
+        while (segment != null)
+        {
+            Debug.Assert(segment.Previous != null);
+            segment.Previous!.Next = null;
+            segment.CellsLeftToResolve = 0;
+            segment = segment.Next;
+        }
+    }
+}

--- a/src/Terrarium.Game/NewOrganism.cs
+++ b/src/Terrarium.Game/NewOrganism.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Diagnostics;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Contains information needed to initialize a new organism.
+/// </summary>
+public class NewOrganism
+{
+    private readonly OrganismState _state;
+    private readonly byte[]? _dna;
+
+    public NewOrganism(OrganismState state, byte[]? dna)
+    {
+        Debug.Assert(!state.IsImmutable);
+        _state = state;
+        _dna = dna;
+    }
+
+    public OrganismState State => _state;
+    public bool AddAtRandomLocation { get; set; } = true;
+    public byte[] Dna => _dna != null ? (byte[])_dna.Clone() : Array.Empty<byte>();
+}

--- a/src/Terrarium.Game/OrganismWorldBoundary.cs
+++ b/src/Terrarium.Game/OrganismWorldBoundary.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Implements an organism's view of the world. In the modernized architecture,
+/// the boundary holds direct references to state accessors rather than global statics.
+/// </summary>
+public class OrganismWorldBoundary : IOrganismWorldBoundary
+{
+    private readonly Func<WorldState> _currentStateAccessor;
+    private readonly Func<int> _worldWidthAccessor;
+    private readonly Func<int> _worldHeightAccessor;
+
+    internal OrganismWorldBoundary(
+        Organism organism, string id,
+        Func<WorldState> currentStateAccessor,
+        Func<int> worldWidthAccessor,
+        Func<int> worldHeightAccessor)
+    {
+        Organism = organism;
+        ID = id;
+        _currentStateAccessor = currentStateAccessor;
+        _worldWidthAccessor = worldWidthAccessor;
+        _worldHeightAccessor = worldHeightAccessor;
+    }
+
+    protected Organism Organism { get; set; }
+
+    public OrganismState CurrentOrganismState
+        => _currentStateAccessor().GetOrganismState(ID)!;
+
+    public string ID { get; private set; }
+    public int WorldWidth => _worldWidthAccessor();
+    public int WorldHeight => _worldHeightAccessor();
+
+    protected void SetOrganismID(string id) => ID = id;
+
+    internal static void SetWorldBoundary(
+        Organism organism, string id,
+        Func<WorldState> currentStateAccessor,
+        Func<int> worldWidthAccessor,
+        Func<int> worldHeightAccessor)
+    {
+        if (organism is Animal)
+            organism.SetWorldBoundary(new AnimalWorldBoundary(organism, id, currentStateAccessor, worldWidthAccessor, worldHeightAccessor));
+        else
+            organism.SetWorldBoundary(new PlantWorldBoundary(organism, id, currentStateAccessor, worldWidthAccessor, worldHeightAccessor));
+    }
+}

--- a/src/Terrarium.Game/PlantSpecies.cs
+++ b/src/Terrarium.Game/PlantSpecies.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Diagnostics;
+using System.Drawing;
+using System.Text;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Holds all species information about a plant.
+/// </summary>
+public sealed class PlantSpecies : Species, IPlantSpecies
+{
+    public PlantSpecies(Type clrType) : base(clrType)
+    {
+        SkinFamily = PlantSkinFamily.Plant;
+        Debug.Assert(clrType != null);
+        Debug.Assert(typeof(Plant).IsAssignableFrom(clrType));
+
+        var skinAttr = (PlantSkinAttribute?)Attribute.GetCustomAttribute(clrType, typeof(PlantSkinAttribute));
+        if (skinAttr != null) { SkinFamily = skinAttr.SkinFamily; Skin = skinAttr.Skin; }
+
+        var seedAttr = (SeedSpreadDistanceAttribute?)Attribute.GetCustomAttribute(clrType, typeof(SeedSpreadDistanceAttribute));
+        if (seedAttr == null) throw new GameEngineException("SeedSpreadDistanceAttribute is required.");
+        SeedSpreadDistance = seedAttr.SeedSpreadDistance;
+    }
+
+    public int SeedSpreadDistance { get; private set; }
+    public PlantSkinFamily SkinFamily { get; private set; }
+    public override int LifeSpan => MatureRadius * EngineSettings.PlantLifeSpanPerUnitMaximumRadius;
+    public override int ReproductionWait => MatureRadius * EngineSettings.PlantReproductionWaitPerUnitRadius;
+
+    public override string GetAttributeWarnings()
+    {
+        var w = new StringBuilder();
+        w.Append(base.GetAttributeWarnings());
+        return w.ToString();
+    }
+
+    public override OrganismState InitializeNewState(Point position, int generation)
+    {
+        var newState = new PlantState(Guid.NewGuid().ToString(), this, generation, EnergyState.Hungry, InitialRadius)
+            { Position = position };
+        newState.ResetGrowthWait();
+        return newState;
+    }
+}

--- a/src/Terrarium.Game/PlantWorldBoundary.cs
+++ b/src/Terrarium.Game/PlantWorldBoundary.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Plant-specific world boundary implementing IPlantWorldBoundary.
+/// </summary>
+public class PlantWorldBoundary : OrganismWorldBoundary, IPlantWorldBoundary
+{
+    private readonly Func<WorldState> _currentStateAccessor;
+
+    internal PlantWorldBoundary(
+        Organism plant, string id,
+        Func<WorldState> currentStateAccessor,
+        Func<int> worldWidthAccessor,
+        Func<int> worldHeightAccessor)
+        : base(plant, id, currentStateAccessor, worldWidthAccessor, worldHeightAccessor)
+    {
+        _currentStateAccessor = currentStateAccessor;
+    }
+
+    public PlantState CurrentPlantState
+        => (PlantState)_currentStateAccessor().GetOrganismState(ID)!;
+}

--- a/src/Terrarium.Game/PopulationData.cs
+++ b/src/Terrarium.Game/PopulationData.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using Microsoft.Extensions.Logging;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Tracks population metrics. Replaces legacy DataSet/WebService with ILogger.
+/// </summary>
+public sealed class PopulationData
+{
+    private const int TicksToReport = 600;
+    private readonly ILogger<PopulationData> _logger;
+    private readonly bool _reportDataToServer;
+    private readonly Dictionary<string, int> _speciesPopulations = new();
+    private int _currentTick = -1;
+    private int _lastReportedTick = -1;
+    private Guid _currentStateGuid;
+
+    public PopulationData(bool reportData, ILogger<PopulationData> logger)
+    { _reportDataToServer = reportData; _logger = logger; }
+
+    public int LastReportedTick => _lastReportedTick;
+    public bool IsReportingTick(int tickNumber) => tickNumber > 0 && tickNumber % TicksToReport == 0;
+
+    public void BeginTick(int tickNumber, Guid stateGuid)
+    { _currentTick = tickNumber; _currentStateGuid = stateGuid; }
+
+    public void EndTick(int tickNumber)
+    {
+        if (IsReportingTick(tickNumber))
+        {
+            _lastReportedTick = tickNumber;
+            if (_reportDataToServer)
+            {
+                // TODO: Sprint 7 - report population data via Orleans grain or HTTP
+                _logger.LogInformation("Population report at tick {Tick}: {Count} species tracked",
+                    tickNumber, _speciesPopulations.Count);
+            }
+        }
+    }
+
+    public void CountOrganism(string speciesName, PopulationChangeReason reason)
+    {
+        _speciesPopulations.TryGetValue(speciesName, out var count);
+        _speciesPopulations[speciesName] = count + 1;
+    }
+
+    public void UncountOrganism(string speciesName, PopulationChangeReason reason)
+    {
+        if (_speciesPopulations.TryGetValue(speciesName, out var count))
+            _speciesPopulations[speciesName] = Math.Max(0, count - 1);
+    }
+
+    public IReadOnlyDictionary<string, int> GetPopulationSnapshot()
+        => new Dictionary<string, int>(_speciesPopulations);
+
+    public void Close() { }
+}

--- a/src/Terrarium.Game/Species.cs
+++ b/src/Terrarium.Game/Species.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Drawing;
+using System.Reflection;
+using System.Text;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Base class for animal and plant species. Contains characteristics
+/// and abilities read from CLR attributes on the creature's Type.
+/// </summary>
+public abstract class Species : ISpecies
+{
+    private readonly string _assemblyFullName;
+    private readonly int _maximumEnergyPerUnitRadius;
+    private readonly string _typeName;
+    private Type? _speciesType;
+
+    protected Species(Type clrType)
+    {
+        MarkingColor = KnownColor.Black;
+        _typeName = clrType.AssemblyQualifiedName!;
+        _assemblyFullName = clrType.Assembly.FullName!;
+
+        var energyAttr = (MaximumEnergyPointsAttribute?)Attribute.GetCustomAttribute(clrType, typeof(MaximumEnergyPointsAttribute));
+        if (energyAttr == null) throw new GameEngineException("MaximumEnergyPointsAttribute is required.");
+        _maximumEnergyPerUnitRadius = energyAttr.MaximumEnergyPerUnitRadius;
+
+        var matureAttr = (MatureSizeAttribute?)Attribute.GetCustomAttribute(clrType, typeof(MatureSizeAttribute));
+        if (matureAttr == null) throw new GameEngineException("MatureSizeAttribute is required.");
+        MatureRadius = matureAttr.MatureRadius;
+
+        var markingAttr = (MarkingColorAttribute?)Attribute.GetCustomAttribute(clrType, typeof(MarkingColorAttribute));
+        if (markingAttr != null) MarkingColor = markingAttr.MarkingColor;
+
+        var authInfo = (AuthorInformationAttribute?)Attribute.GetCustomAttribute(clrType.Assembly, typeof(AuthorInformationAttribute));
+        if (authInfo == null || string.IsNullOrEmpty(authInfo.AuthorName))
+            throw new GameEngineException("AuthorInformationAttribute is required.");
+        AuthorName = authInfo.AuthorName;
+        AuthorEmail = authInfo.AuthorEmail;
+        Name = GetAssemblyShortName(clrType.Assembly.FullName!);
+    }
+
+    internal Type Type
+    {
+        get
+        {
+            if (_speciesType != null) return _speciesType;
+            try { _speciesType = Type.GetType(_typeName); } catch { }
+            _speciesType ??= typeof(Organism);
+            return _speciesType;
+        }
+    }
+
+    public string AuthorName { get; private set; }
+    public string AuthorEmail { get; private set; }
+    public KnownColor MarkingColor { get; private set; }
+    public int InitialRadius => (EngineSettings.MinMatureSize / 2) - 1;
+    public string Name { get; private set; }
+    public string AssemblyFullName => _assemblyFullName;
+    public int MatureRadius { get; private set; }
+    public string Skin { get; protected set; } = string.Empty;
+    public abstract int ReproductionWait { get; }
+    public abstract int LifeSpan { get; }
+    public int GrowthWait => (LifeSpan / 2) / (MatureRadius - InitialRadius);
+    public int MaximumEnergyPerUnitRadius => _maximumEnergyPerUnitRadius;
+
+    public bool IsSameSpecies(ISpecies species) => ((Species)species).Type == Type;
+
+    public virtual string GetAttributeWarnings()
+    {
+        var warnings = new StringBuilder();
+        var ea = (MaximumEnergyPointsAttribute?)Attribute.GetCustomAttribute(Type, typeof(MaximumEnergyPointsAttribute));
+        var w = ea?.GetWarnings() ?? "";
+        if (w.Length != 0) { warnings.Append(w); warnings.Append(Environment.NewLine); }
+        return warnings.ToString();
+    }
+
+    public abstract OrganismState InitializeNewState(Point position, int generation);
+
+    public static Species GetSpeciesFromAssembly(Assembly organismAssembly)
+    {
+        var hasAttr = false;
+        var attributes = Attribute.GetCustomAttributes(organismAssembly);
+        if (attributes.Length == 0) throw new GameEngineException("OrganismClassAttribute is required.");
+        foreach (var a in attributes) { if (a.GetType().Name == "OrganismClassAttribute") { hasAttr = true; break; } }
+
+        var classAttr = (OrganismClassAttribute?)Attribute.GetCustomAttribute(organismAssembly, typeof(OrganismClassAttribute));
+        if (classAttr == null)
+        {
+            if (hasAttr) throw new GameEngineException("Your organism is built against a different version of Terrarium. Try rebuilding it.");
+            throw new GameEngineException("OrganismClassAttribute is required.");
+        }
+
+        Type clrType;
+        try { clrType = organismAssembly.GetType(classAttr.ClassName, true)!; }
+        catch (TypeLoadException) { throw new GameEngineException($"Your organism {classAttr.ClassName} could not be found in the assembly."); }
+
+        if (typeof(Plant).IsAssignableFrom(clrType)) return new PlantSpecies(clrType);
+        if (typeof(Animal).IsAssignableFrom(clrType)) return new AnimalSpecies(clrType);
+        throw new GameEngineException($"Class specified in OrganismClassAttribute ({classAttr.ClassName}) doesn't derive from Animal or Plant");
+    }
+
+    internal static string GetAssemblyShortName(string fullName)
+    {
+        var idx = fullName.IndexOf(',');
+        return idx > 0 ? fullName[..idx] : fullName;
+    }
+}

--- a/src/Terrarium.Game/TeleportZone.cs
+++ b/src/Terrarium.Game/TeleportZone.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Drawing;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// A moving teleportation zone in the Terrarium world.
+/// </summary>
+public class TeleportZone
+{
+    private readonly int _teleportID;
+    private Rectangle _rectangle;
+    private MovementVector? _vector;
+
+    public TeleportZone(Rectangle rectangle, MovementVector? vector, int id)
+    { _rectangle = rectangle; _vector = vector; _teleportID = id; }
+
+    public Rectangle Rectangle => new(_rectangle.Left, _rectangle.Top, _rectangle.Width, _rectangle.Height);
+    public int ID => _teleportID;
+    public MovementVector? Vector => _vector;
+
+    public TeleportZone Clone() => new(_rectangle, _vector, ID);
+
+    public TeleportZone SetRectangle(Rectangle rectangle)
+    { var z = Clone(); z._rectangle = rectangle; return z; }
+
+    public TeleportZone SetVector(MovementVector? vector)
+    { var z = Clone(); z._vector = vector; return z; }
+
+    public bool Contains(OrganismState state)
+    {
+        var d = _rectangle.Left - (state.Position.X - state.Radius);
+        if (d < 0) { if (-d > _rectangle.Width + 1) return false; }
+        else { if (d > (state.Radius * 2) + 1) return false; }
+        d = _rectangle.Top - (state.Position.Y - state.Radius);
+        if (d < 0) { if (-d > _rectangle.Height + 1) return false; }
+        else { if (d > (state.Radius * 2) + 1) return false; }
+        return true;
+    }
+}

--- a/src/Terrarium.Game/Teleporter.cs
+++ b/src/Terrarium.Game/Teleporter.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Drawing;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Manages a set of moving teleport zones.
+/// </summary>
+public class Teleporter
+{
+    private readonly TeleportZone[] _teleportZones;
+    private Random _random = new(DateTime.Now.Millisecond);
+
+    public Teleporter(int zoneCount)
+    {
+        if (zoneCount == 0) zoneCount = 1;
+        _teleportZones = new TeleportZone[zoneCount];
+        for (var i = 0; i < zoneCount; i++)
+            _teleportZones[i] = new TeleportZone(new Rectangle(225, 225, 48, 48), null, i);
+    }
+
+    public Teleporter Clone()
+    {
+        var t = new Teleporter(_teleportZones.Length);
+        for (var i = 0; i < _teleportZones.Length; i++) t._teleportZones[i] = _teleportZones[i];
+        return t;
+    }
+
+    public void Move(int worldWidth, int worldHeight)
+    {
+        for (var i = 0; i < _teleportZones.Length; i++)
+        {
+            var tz = _teleportZones[i];
+            if (tz == null) continue;
+            if (tz.Vector == null || tz.Rectangle.Contains(tz.Vector.Destination))
+            {
+                _teleportZones[i] = tz.SetVector(new MovementVector(
+                    new Point(_random.Next(0, worldWidth), _random.Next(0, worldHeight)), 5));
+            }
+            else
+            {
+                var r = tz.Rectangle;
+                var v = Vector.Subtract(r.Location, tz.Vector.Destination);
+                if (v.Magnitude <= tz.Vector.Speed) { _teleportZones[i] = tz.SetVector(null); }
+                else
+                {
+                    var uv = v.GetUnitVector();
+                    var sv = uv.Scale(tz.Vector.Speed);
+                    r.Location = Vector.Add(r.Location, sv);
+                    _teleportZones[i] = tz.SetRectangle(r);
+                }
+            }
+        }
+    }
+
+    public bool IsInTeleporter(OrganismState state)
+    {
+        foreach (var z in _teleportZones) if (z.Contains(state)) return true;
+        return false;
+    }
+
+    public TeleportZone GetTeleportZone(int id) => _teleportZones[id];
+    public TeleportZone[] GetTeleportZones() => (TeleportZone[])_teleportZones.Clone();
+}

--- a/src/Terrarium.Game/Terrarium.Game.csproj
+++ b/src/Terrarium.Game/Terrarium.Game.csproj
@@ -2,6 +2,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Terrarium.OrganismBase\Terrarium.OrganismBase.csproj" />
+    <ProjectReference Include="..\Terrarium.Configuration\Terrarium.Configuration.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Terrarium.Game/TerrariumSprite.cs
+++ b/src/Terrarium.Game/TerrariumSprite.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Sprite rendering metadata. Headless - no DirectX/WPF dependencies.
+/// </summary>
+public class TerrariumSprite
+{
+    public bool IsPlant { get; set; }
+    public int FrameHeight => 48;
+    public int FrameWidth => 48;
+    public string? SkinFamily { get; set; }
+    public float CurFrame { get; set; }
+    public float CurFrameDelta { get; set; }
+    public float XPosition { get; set; }
+    public float YPosition { get; set; }
+    public float XDelta { get; set; }
+    public float YDelta { get; set; }
+    public bool Selected { get; set; }
+    public DisplayAction PreviousAction { get; set; }
+    public string? SpriteKey { get; set; }
+
+    public void AdvanceFrame()
+    {
+        if (CurFrame != 0) { XPosition += XDelta; YPosition += YDelta; }
+        CurFrame = (CurFrame + CurFrameDelta) % 10;
+    }
+}

--- a/src/Terrarium.Game/TickActions.cs
+++ b/src/Terrarium.Game/TickActions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Aggregates all creature actions for a single game tick.
+/// </summary>
+public class TickActions
+{
+    private readonly Dictionary<string, MoveToAction> _moveToActions = new();
+    private readonly Dictionary<string, AttackAction> _attackActions = new();
+    private readonly Dictionary<string, EatAction> _eatActions = new();
+    private readonly Dictionary<string, ReproduceAction> _reproduceActions = new();
+    private readonly Dictionary<string, DefendAction> _defendActions = new();
+
+    public IReadOnlyDictionary<string, MoveToAction> MoveToActions => new Dictionary<string, MoveToAction>(_moveToActions);
+    public IReadOnlyDictionary<string, AttackAction> AttackActions => new Dictionary<string, AttackAction>(_attackActions);
+    public IReadOnlyDictionary<string, EatAction> EatActions => new Dictionary<string, EatAction>(_eatActions);
+    public IReadOnlyDictionary<string, ReproduceAction> ReproduceActions => new Dictionary<string, ReproduceAction>(_reproduceActions);
+    public IReadOnlyDictionary<string, DefendAction> DefendActions => new Dictionary<string, DefendAction>(_defendActions);
+
+    internal void GatherActionsFromOrganisms(IEnumerable<Organism> organisms)
+    {
+        foreach (var organism in organisms)
+        {
+            var id = organism.ID;
+            var pa = organism.GetThenErasePendingActions();
+            if (pa.MoveToAction != null) _moveToActions[id] = pa.MoveToAction;
+            if (pa.AttackAction != null) _attackActions[id] = pa.AttackAction;
+            if (pa.EatAction != null) _eatActions[id] = pa.EatAction;
+            if (pa.ReproduceAction != null) _reproduceActions[id] = pa.ReproduceAction;
+            if (pa.DefendAction != null) _defendActions[id] = pa.DefendAction;
+        }
+    }
+}

--- a/src/Terrarium.Game/WorldState.cs
+++ b/src/Terrarium.Game/WorldState.cs
@@ -1,0 +1,352 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Diagnostics;
+using OrganismBase;
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Contains the full state of the world at a given tick. Holds state objects
+/// for all organisms. Immutable once a game tick is finalized.
+/// Replaces legacy Hashtable/ArrayList with Dictionary/List.
+/// </summary>
+public sealed class WorldState
+{
+    private readonly OrganismState?[,] _cellOrganisms;
+    private readonly int _gridWidth;
+    private readonly int _gridHeight;
+
+    private readonly byte[,] _invisible =
+        new byte[
+            (EngineSettings.MaximumEyesightRadius + EngineSettings.BaseEyesightRadius + EngineSettings.MaxGridRadius) * 2 + 1,
+            (EngineSettings.MaximumEyesightRadius + EngineSettings.BaseEyesightRadius + EngineSettings.MaxGridRadius) * 2 + 1];
+
+    private readonly Dictionary<string, OrganismState> _organisms = new();
+    private bool _indexBuilt;
+    private bool _isImmutable;
+    private List<OrganismState>? _orgs;
+    private Guid _stateGuid;
+    private Teleporter? _teleporter;
+    private int _tickNumber;
+
+    public WorldState(int gridWidth, int gridHeight)
+    {
+        _gridWidth = gridWidth;
+        _gridHeight = gridHeight;
+        _cellOrganisms = new OrganismState?[gridWidth, gridHeight];
+    }
+
+    public bool IndexBuilt => _indexBuilt;
+    public ICollection<OrganismState> Organisms => _organisms.Values;
+
+    public IReadOnlyList<OrganismState> ZOrderedOrganisms
+    {
+        get
+        {
+            if (_orgs == null)
+            {
+                _orgs = new List<OrganismState>(_organisms.Values);
+                _orgs.Sort();
+            }
+            return _orgs;
+        }
+    }
+
+    public Guid StateGuid
+    {
+        get => _stateGuid;
+        set
+        {
+            if (IsImmutable) throw new InvalidOperationException("WorldState is immutable.");
+            _stateGuid = value;
+        }
+    }
+
+    public int TickNumber
+    {
+        get => _tickNumber;
+        set
+        {
+            if (IsImmutable) throw new InvalidOperationException("WorldState is immutable.");
+            _tickNumber = value;
+        }
+    }
+
+    public Teleporter? Teleporter
+    {
+        get => _teleporter;
+        set
+        {
+            if (IsImmutable) throw new InvalidOperationException("WorldState is immutable.");
+            _teleporter = value;
+        }
+    }
+
+    public ICollection<string> OrganismIDs => _organisms.Keys;
+    public bool IsImmutable => _isImmutable;
+
+    public WorldState DuplicateMutable()
+    {
+        var newState = new WorldState(_gridWidth, _gridHeight);
+        foreach (var state in Organisms)
+        {
+            var ns = state.CloneMutable();
+            Debug.Assert(ns != null);
+            Debug.Assert(ns.ID != null);
+            newState._organisms.Add(ns.ID, ns);
+        }
+        newState._tickNumber = _tickNumber;
+        newState._stateGuid = _stateGuid;
+        if (_teleporter != null) newState._teleporter = _teleporter.Clone();
+        return newState;
+    }
+
+    public void ClearIndex()
+    {
+        if (_isImmutable) throw new InvalidOperationException("WorldState must be mutable.");
+        for (var x = 0; x < _gridWidth; x++)
+            for (var y = 0; y < _gridHeight; y++)
+                _cellOrganisms[x, y] = null;
+        _indexBuilt = false;
+    }
+
+    public void BuildIndex() => BuildIndexInternal(false);
+
+    private void BuildIndexInternal(bool isDeserializing)
+    {
+        if (!isDeserializing && _isImmutable)
+            throw new InvalidOperationException("WorldState must be mutable to rebuild index.");
+        if (_organisms.Count > 0)
+        {
+            foreach (var state in Organisms)
+            {
+                Debug.Assert(state.GridX >= 0 && state.GridX < _gridWidth && state.GridY >= 0 && state.GridY < _gridHeight);
+                Debug.Assert(_cellOrganisms[state.GridX, state.GridY] == null);
+                FillCells(state, state.GridX, state.GridY, state.CellRadius, false);
+                if (!isDeserializing) state.LockSizeAndPosition();
+            }
+        }
+        _indexBuilt = true;
+    }
+
+    public void FillCells(OrganismState state, int cellX, int cellY, int cellRadius, bool clear)
+    {
+        Debug.Assert(cellX - cellRadius >= 0 && cellY - cellRadius + 1 >= 0);
+        for (var x = cellX - cellRadius; x <= cellX + cellRadius; x++)
+            for (var y = cellY - cellRadius; y <= cellY + cellRadius; y++)
+            {
+                if (clear)
+                {
+                    Debug.Assert(_cellOrganisms[x, y] == null || _cellOrganisms[x, y]!.ID == state.ID);
+                    _cellOrganisms[x, y] = null;
+                }
+                else
+                {
+                    Debug.Assert(_cellOrganisms[x, y] == null);
+                    _cellOrganisms[x, y] = state;
+                }
+            }
+    }
+
+    public void AddOrganism(OrganismState state)
+    {
+        if (IsImmutable) throw new InvalidOperationException("WorldState must be mutable to add organisms.");
+        Debug.Assert(state.GridX >= 0 && state.GridX < _gridWidth && state.GridY >= 0 && state.GridY < _gridHeight);
+        Debug.Assert(_cellOrganisms[state.GridX, state.GridY] == null);
+        if (_organisms.ContainsKey(state.ID))
+            throw new InvalidOperationException("Organism already exists in this world state.");
+        FillCells(state, state.GridX, state.GridY, state.CellRadius, false);
+        state.LockSizeAndPosition();
+        _organisms.Add(state.ID, state);
+    }
+
+    public void RefreshOrganism(OrganismState state)
+    {
+        if (IsImmutable) throw new InvalidOperationException("WorldState must be mutable to change.");
+        var id = state.ID;
+        if (IndexBuilt)
+        {
+            var oldState = GetOrganismState(id);
+            if (oldState != null) FillCells(oldState, oldState.GridX, oldState.GridY, oldState.CellRadius, true);
+        }
+        _organisms.Remove(id);
+        AddOrganism(state);
+    }
+
+    public void RemoveOrganism(string organismID)
+    {
+        if (IsImmutable) throw new InvalidOperationException("WorldState must be mutable to change.");
+        if (IndexBuilt)
+        {
+            var state = GetOrganismState(organismID);
+            if (state != null) FillCells(state, state.GridX, state.GridY, state.CellRadius, true);
+        }
+        _organisms.Remove(organismID);
+    }
+
+    public OrganismState? GetOrganismState(string organismID)
+    {
+        _organisms.TryGetValue(organismID, out var state);
+        return state;
+    }
+
+    public void MakeImmutable()
+    {
+        foreach (var state in Organisms) state.MakeImmutable();
+        _isImmutable = true;
+    }
+
+    public List<OrganismState> FindOrganisms(int x1, int x2, int y1, int y2)
+    {
+        int minX, maxX, minY, maxY;
+        if (x1 < x2) { minX = x1; maxX = x2; } else { minX = x2; maxX = x1; }
+        if (y1 < y2) { minY = y1; maxY = y2; } else { minY = y2; maxY = y1; }
+        if (minX < 0) minX = 0; if (maxX < 0) maxX = 0;
+        if (minY < 0) minY = 0; if (maxY < 0) maxY = 0;
+        minX >>= EngineSettings.GridWidthPowerOfTwo;
+        if (minX > _gridWidth - 1) minX = _gridWidth - 1;
+        maxX >>= EngineSettings.GridWidthPowerOfTwo;
+        if (maxX > _gridWidth - 1) maxX = _gridWidth - 1;
+        minY >>= EngineSettings.GridHeightPowerOfTwo;
+        if (minY > _gridHeight - 1) minY = _gridHeight - 1;
+        maxY >>= EngineSettings.GridHeightPowerOfTwo;
+        if (maxY > _gridHeight - 1) maxY = _gridHeight - 1;
+        return FindOrganismsInCells(minX, maxX, minY, maxY);
+    }
+
+    public int GetAvailableLight(PlantState plant)
+    {
+        var maxX = plant.GridX + plant.CellRadius + 25;
+        if (maxX > _gridWidth - 1) maxX = _gridWidth - 1;
+        var east = FindOrganismsInCells(plant.GridX + plant.CellRadius, maxX,
+            plant.GridY - plant.CellRadius, plant.GridY + plant.CellRadius);
+        var minX = plant.GridX - plant.CellRadius - 25;
+        if (minX < 0) minX = 0;
+        var west = FindOrganismsInCells(minX, plant.GridX - plant.CellRadius,
+            plant.GridY - plant.CellRadius, plant.GridY + plant.CellRadius);
+
+        double maxAngleEast = 0;
+        foreach (var t in east)
+        {
+            if (t is not PlantState ps) continue;
+            var a = Math.Atan2(ps.Height, t.Position.X - plant.Position.X);
+            if (a > maxAngleEast) maxAngleEast = a;
+        }
+        double maxAngleWest = 0;
+        foreach (var t in west)
+        {
+            if (t is not PlantState ps) continue;
+            var a = Math.Atan2(ps.Height, plant.Position.X - t.Position.X);
+            if (a > maxAngleWest) maxAngleWest = a;
+        }
+        return (int)(((Math.PI - maxAngleEast + maxAngleWest) / Math.PI) * 100);
+    }
+
+    public bool OnlyOverlapsSelf(OrganismState state)
+    {
+        Debug.Assert(IndexBuilt);
+        var minGX = state.GridX - state.CellRadius; var maxGX = state.GridX + state.CellRadius;
+        var minGY = state.GridY - state.CellRadius; var maxGY = state.GridY + state.CellRadius;
+        if (minGX < 0 || maxGX > _gridWidth - 1 || minGY < 0 || maxGY > _gridHeight - 1) return false;
+        for (var x = minGX; x <= maxGX; x++)
+            for (var y = minGY; y <= maxGY; y++)
+            {
+                if (_cellOrganisms[x, y] == null) continue;
+                if (_cellOrganisms[x, y]!.ID != state.ID) return false;
+            }
+        return true;
+    }
+
+    public List<OrganismState> FindOrganismsInCells(int minGridX, int maxGridX, int minGridY, int maxGridY)
+    {
+        Debug.Assert(IndexBuilt);
+        Debug.Assert(minGridX <= maxGridX && minGridY <= maxGridY);
+        Debug.Assert(minGridX >= 0 && maxGridX < _gridWidth && minGridY >= 0 && maxGridY < _gridHeight);
+        OrganismState? lastFound = null;
+        var foundHash = new HashSet<OrganismState>();
+        var foundOrganisms = new List<OrganismState>();
+        for (var x = minGridX; x <= maxGridX; x++)
+            for (var y = minGridY; y <= maxGridY; y++)
+            {
+                var current = _cellOrganisms[x, y];
+                if (current == null) continue;
+                if (lastFound != null && lastFound == current) continue;
+                if (foundHash.Add(current)) foundOrganisms.Add(current);
+                lastFound = current;
+            }
+        return foundOrganisms;
+    }
+
+    public List<OrganismState> FindOrganismsInView(OrganismState state, int radius)
+    {
+        Debug.Assert(IndexBuilt);
+        Debug.Assert((state.CellRadius + radius) * 2 + 1 <= _invisible.GetLength(0));
+        var foundOrganisms = new List<OrganismState>();
+        var foundHash = new HashSet<OrganismState>();
+        var oX = state.GridX; var oY = state.GridY;
+        var mX = -oX + state.CellRadius + radius;
+        var mY = -oY + state.CellRadius + radius;
+        int xI = 0, yI = 0;
+
+        var cr = state.CellRadius + 1;
+        var cx = oX - cr; var cy = oY - cr;
+        for (var s = 0; s < 4; s++)
+        {
+            switch (s) { case 0: xI=1; yI=0; break; case 1: xI=0; yI=1; break; case 2: xI=-1; yI=0; break; case 3: xI=0; yI=-1; break; }
+            for (var c = 0; c < cr << 1; c++)
+            {
+                if (cx >= 0 && cy >= 0 && cx < _gridWidth && cy < _gridHeight)
+                {
+                    var co = _cellOrganisms[cx, cy];
+                    if (co != null && foundHash.Add(co)) foundOrganisms.Add(co);
+                    _invisible[cx + mX, cy + mY] = 0;
+                }
+                cx += xI; cy += yI;
+            }
+        }
+
+        for (cr = state.CellRadius + 2; cr <= state.CellRadius + radius; cr++)
+        {
+            cx = oX - cr; cy = oY - cr;
+            for (var s = 0; s < 4; s++)
+            {
+                switch (s) { case 0: xI=1; yI=0; break; case 1: xI=0; yI=1; break; case 2: xI=-1; yI=0; break; case 3: xI=0; yI=-1; break; }
+                for (var c = 0; c < cr << 1; c++)
+                {
+                    if (cx >= 0 && cy >= 0 && cx < _gridWidth && cy < _gridHeight)
+                    {
+                        var i = cx - oX; var j = cy - oY;
+                        int sI = i < 0 ? 1 : i > 0 ? -1 : 0;
+                        int sJ = j < 0 ? 1 : j > 0 ? -1 : 0;
+                        int aI = i < 0 ? -i : i; int aJ = j < 0 ? -j : j;
+                        int p1X, p1Y;
+                        if (aJ > aI) { p1X = cx; p1Y = sJ + cy; } else { p1X = sI + cx; p1Y = sJ + cy; }
+                        int p2X, p2Y;
+                        if (aJ != aI) { p2X = sI + cx; p2Y = sJ + cy; } else { p2X = p1X; p2Y = p1Y; }
+                        if (_invisible[p1X + mX, p1Y + mY] == 1 || _invisible[p2X + mX, p2Y + mY] == 1)
+                            _invisible[cx + mX, cy + mY] = 1;
+                        else
+                        {
+                            var co = _cellOrganisms[cx, cy];
+                            if (co != null)
+                            {
+                                _invisible[cx + mX, cy + mY] = 1;
+                                if (foundHash.Add(co)) foundOrganisms.Add(co);
+                            }
+                            else _invisible[cx + mX, cy + mY] = 0;
+                        }
+                    }
+                    cx += xI; cy += yI;
+                }
+            }
+        }
+        return foundOrganisms;
+    }
+
+    public bool IsGridCellOccupied(int cellX, int cellY)
+    {
+        Debug.Assert(IndexBuilt);
+        Debug.Assert(cellX < _gridWidth && cellY < _gridHeight && cellX >= 0 && cellY >= 0);
+        return _cellOrganisms[cellX, cellY] != null;
+    }
+}

--- a/src/Terrarium.Game/WorldVector.cs
+++ b/src/Terrarium.Game/WorldVector.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+namespace Terrarium.Game;
+
+/// <summary>
+/// Contains world state + the actions organisms want to perform next.
+/// </summary>
+public class WorldVector
+{
+    private TickActions? _currentActions;
+
+    public WorldVector(WorldState state)
+    {
+        if (!state.IsImmutable)
+            throw new InvalidOperationException("WorldState must be immutable to be added to vector.");
+        State = state;
+    }
+
+    public TickActions Actions
+    {
+        get => _currentActions!;
+        set => _currentActions = value ?? throw new InvalidOperationException("Actions can't be null.");
+    }
+
+    public WorldState State { get; private set; }
+}


### PR DESCRIPTION
## Sprint 4: Game Engine Core

Ports the heart of Terrarium from legacy .NET Framework to .NET 10.

### Issues
- Closes #29 — Port GameEngine core loop
- Closes #30 — Port creature management classes
- Closes #31 — Port spatial indexing
- Closes #32 — Port movement and physics

### Changes
- **GameEngine.cs**: 10-phase ProcessTurn() loop with ILogger diagnostics
- **WorldState.cs**: Immutable 2D cell grid world snapshot (Dictionary/List)
- **WorldVector.cs** + **TickActions.cs**: World direction + action aggregation
- **Species/AnimalSpecies/PlantSpecies**: Creature trait management from CLR attributes
- **NewOrganism.cs** + **KilledOrganism.cs**: Organism lifecycle management
- **OrganismWorldBoundary/AnimalWorldBoundary/PlantWorldBoundary**: Interface bridge for creatures
- **GridIndex.cs** + **MovementSegment.cs**: Spatial collision solver (Bresenham + cell partitioning)
- **Teleporter/TeleportZone**: Cross-world teleportation zones
- **PopulationData.cs**: Population metrics with ILogger
- **TerrariumSprite.cs**: Headless sprite rendering metadata

### Modernization
- All Hashtable → Dictionary\<TKey, TValue\>
- All ArrayList → List\<T\>
- BinaryFormatter → System.Text.Json (TODO comments for Sprint 7)
- Zero WinForms/WPF dependencies — fully headless
- ILogger\<T\> replaces System.Diagnostics.Trace
- Nullable reference types enabled
- TODO: Sprint 7 comments for Orleans scheduler integration