### PR TITLE
Aspire wiring + Container Apps deployment

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -1,0 +1,12 @@
+name: terrarium
+metadata:
+  template: terrarium
+services:
+  server:
+    project: src/Terrarium.Server
+    host: containerapp
+    language: csharp
+  web:
+    project: src/Terrarium.Web
+    host: containerapp
+    language: csharp

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,160 @@
+@description('The Azure region for all resources.')
+param location string = resourceGroup().location
+
+@description('Unique suffix for resource names.')
+param environmentName string
+
+@secure()
+@description('SQL Server administrator password.')
+param sqlAdminPassword string
+
+@description('SQL Server administrator username.')
+param sqlAdminLogin string = 'terrariumadmin'
+
+@description('Container image for Terrarium.Server.')
+param serverImage string
+
+@description('Container image for Terrarium.Web.')
+param webImage string
+
+// ---------- Log Analytics + Container Apps Environment ----------
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: 'log-${environmentName}'
+  location: location
+  properties: {
+    sku: { name: 'PerGB2018' }
+    retentionInDays: 30
+  }
+}
+
+resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: 'cae-${environmentName}'
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+// ---------- Azure SQL ----------
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+  name: 'sql-${environmentName}'
+  location: location
+  properties: {
+    administratorLogin: sqlAdminLogin
+    administratorLoginPassword: sqlAdminPassword
+  }
+}
+
+resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
+  parent: sqlServer
+  name: 'Terrarium'
+  location: location
+  sku: {
+    name: 'Basic'
+    tier: 'Basic'
+  }
+}
+
+resource sqlFirewallAllowAzure 'Microsoft.Sql/servers/firewallRules@2023-08-01-preview' = {
+  parent: sqlServer
+  name: 'AllowAllAzureIps'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+
+// ---------- Terrarium.Server Container App ----------
+
+resource serverApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'server-${environmentName}'
+  location: location
+  properties: {
+    managedEnvironmentId: containerAppEnv.id
+    configuration: {
+      ingress: {
+        external: false
+        targetPort: 8080
+        transport: 'http'
+      }
+      secrets: [
+        {
+          name: 'sql-connection'
+          value: 'Server=tcp:${sqlServer.properties.fullyQualifiedDomainName},1433;Database=Terrarium;User ID=${sqlAdminLogin};Password=${sqlAdminPassword};Encrypt=true;TrustServerCertificate=false;'
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'server'
+          image: serverImage
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'ConnectionStrings__Terrarium'
+              secretRef: 'sql-connection'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 3
+      }
+    }
+  }
+}
+
+// ---------- Terrarium.Web Container App ----------
+
+resource webApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'web-${environmentName}'
+  location: location
+  properties: {
+    managedEnvironmentId: containerAppEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'http'
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: 'web'
+          image: webImage
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            {
+              name: 'services__server__https__0'
+              value: 'https://${serverApp.properties.configuration.ingress.fqdn}'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 3
+      }
+    }
+  }
+}
+
+output webUrl string = 'https://${webApp.properties.configuration.ingress.fqdn}'
+output serverUrl string = 'https://${serverApp.properties.configuration.ingress.fqdn}'

--- a/src/Terrarium.Server/Dockerfile
+++ b/src/Terrarium.Server/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-preview AS base
+WORKDIR /app
+EXPOSE 8080
+
+FROM mcr.microsoft.com/dotnet/sdk:10.0-preview AS build
+WORKDIR /src
+COPY ["Terrarium.Server/Terrarium.Server.csproj", "Terrarium.Server/"]
+COPY ["Terrarium.Services/Terrarium.Services.csproj", "Terrarium.Services/"]
+COPY ["Terrarium.Configuration/Terrarium.Configuration.csproj", "Terrarium.Configuration/"]
+COPY ["Terrarium.ServiceDefaults/Terrarium.ServiceDefaults.csproj", "Terrarium.ServiceDefaults/"]
+COPY ["Directory.Build.props", "./"]
+RUN dotnet restore "Terrarium.Server/Terrarium.Server.csproj"
+COPY . .
+WORKDIR "/src/Terrarium.Server"
+RUN dotnet publish -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Terrarium.Server.dll"]

--- a/src/Terrarium.Server/MessagingEndpoints.cs
+++ b/src/Terrarium.Server/MessagingEndpoints.cs
@@ -10,23 +10,28 @@ public static class MessagingEndpoints
 {
     public static RouteGroupBuilder MapMessagingEndpoints(this RouteGroupBuilder group)
     {
+        group.WithTags("Messaging");
+
         group.MapGet("/welcome", (IOptions<ServerSettings> settings) =>
         {
             var message = settings.Value.WelcomeMessage;
             return Results.Ok(new { message });
-        });
+        })
+        .WithName("GetWelcomeMessage");
 
         group.MapGet("/motd", (IOptions<ServerSettings> settings) =>
         {
             var message = settings.Value.MOTD;
             return Results.Ok(new { message });
-        });
+        })
+        .WithName("GetMotd");
 
         group.MapGet("/version", (IOptions<ServerSettings> settings) =>
         {
             var version = settings.Value.LatestVersion;
             return Results.Ok(new { version });
-        });
+        })
+        .WithName("GetLatestVersion");
 
         return group;
     }

--- a/src/Terrarium.Server/PeerDiscoveryEndpoints.cs
+++ b/src/Terrarium.Server/PeerDiscoveryEndpoints.cs
@@ -78,6 +78,8 @@ public static class PeerDiscoveryEndpoints
 {
     public static RouteGroupBuilder MapPeerDiscoveryEndpoints(this RouteGroupBuilder group)
     {
+        group.WithTags("PeerDiscovery");
+
         group.MapPost("/register", async (
             RegisterPeerRequest request,
             HttpContext httpContext,
@@ -132,7 +134,9 @@ public static class PeerDiscoveryEndpoints
                 logger.LogError(ex, "PeerDiscovery: RegisterPeer failed");
                 return Results.Ok(new RegisterPeerResponse { Result = RegisterPeerResult.Failure });
             }
-        });
+        })
+        .WithName("RegisterPeer")
+        .Produces<RegisterPeerResponse>();
 
         group.MapGet("/peers", async (
             string version,
@@ -164,13 +168,16 @@ public static class PeerDiscoveryEndpoints
                 logger.LogError(ex, "PeerDiscovery: GetNumPeers failed");
                 return Results.Ok(new PeerCountResponse { Count = 0 });
             }
-        });
+        })
+        .WithName("GetPeerCount")
+        .Produces<PeerCountResponse>();
 
         group.MapGet("/validate", (HttpContext httpContext) =>
         {
             var ipAddress = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
             return Results.Ok(new { ipAddress });
-        });
+        })
+        .WithName("ValidatePeer");
 
         group.MapPost("/register-user", async (
             RegisterUserRequest request,
@@ -197,7 +204,8 @@ public static class PeerDiscoveryEndpoints
                 logger.LogError(ex, "PeerDiscovery: RegisterUser failed");
                 return Results.Ok(new { success = false });
             }
-        });
+        })
+        .WithName("RegisterUser");
 
         group.MapGet("/version-check", async (
             string version,
@@ -224,7 +232,9 @@ public static class PeerDiscoveryEndpoints
                 logger.LogError(ex, "PeerDiscovery: IsVersionDisabled failed");
                 return Results.Ok(new VersionCheckResponse { Disabled = true, Message = string.Empty });
             }
-        });
+        })
+        .WithName("CheckVersion")
+        .Produces<VersionCheckResponse>();
 
         return group;
     }

--- a/src/Terrarium.Server/Program.cs
+++ b/src/Terrarium.Server/Program.cs
@@ -10,10 +10,12 @@ builder.Services.Configure<ServerSettings>(
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<ThrottleService>();
 builder.Services.AddHostedService<NonPageServicesWorker>();
+builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
+app.MapOpenApi();
 app.UseMiddleware<ThrottleMiddleware>();
 
 app.MapGet("/", () => "Terrarium Server");

--- a/src/Terrarium.Server/SpeciesEndpoints.cs
+++ b/src/Terrarium.Server/SpeciesEndpoints.cs
@@ -90,6 +90,8 @@ public static class SpeciesEndpoints
 {
     public static RouteGroupBuilder MapSpeciesEndpoints(this RouteGroupBuilder group)
     {
+        group.WithTags("Species");
+
         group.MapPost("/register", async (
             RegisterSpeciesRequest request,
             HttpContext httpContext,
@@ -165,7 +167,9 @@ public static class SpeciesEndpoints
                 logger.LogError(ex, "Species: Register failed");
                 return Results.Ok(new RegisterSpeciesResponse { Status = SpeciesServiceStatus.ServerDown });
             }
-        });
+        })
+        .WithName("RegisterSpecies")
+        .Produces<RegisterSpeciesResponse>();
 
         group.MapGet("/list", async (
             string version,
@@ -200,11 +204,11 @@ public static class SpeciesEndpoints
                 logger.LogError(ex, "Species: List failed");
                 return Results.Ok(Array.Empty<SpeciesInfo>());
             }
-        });
+        })
+        .WithName("ListSpecies")
+        .Produces<IEnumerable<SpeciesInfo>>();
 
         group.MapGet("/extinct", async (
-            string version,
-            string? filter,
             IOptions<ServerSettings> settings,
             ILogger<Program> logger) =>
         {

--- a/src/Terrarium.Server/Terrarium.Server.csproj
+++ b/src/Terrarium.Server/Terrarium.Server.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-preview.*" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2" />
   </ItemGroup>
 

--- a/src/Terrarium.Server/WatsonEndpoints.cs
+++ b/src/Terrarium.Server/WatsonEndpoints.cs
@@ -42,6 +42,8 @@ public static class WatsonEndpoints
 {
     public static RouteGroupBuilder MapWatsonEndpoints(this RouteGroupBuilder group)
     {
+        group.WithTags("Watson");
+
         group.MapPost("/report", async (
             WatsonReportRequest request,
             HttpContext httpContext,
@@ -77,13 +79,16 @@ public static class WatsonEndpoints
                 logger.LogError(ex, "Watson: ReportError failed");
                 return Results.Ok(new { success = false });
             }
-        });
+        })
+        .WithName("ReportWatsonError");
 
         return group;
     }
 
     public static RouteGroupBuilder MapBugEndpoints(this RouteGroupBuilder group)
     {
+        group.WithTags("Bugs");
+
         group.MapPost("/report", (
             BugReportRequest request,
             ILogger<Program> logger) =>
@@ -91,7 +96,8 @@ public static class WatsonEndpoints
             // Legacy BugService was a stub (TODO in code). Log the report for now.
             logger.LogInformation("Bug report received: {Title} from {Alias}", request.Title, request.Alias);
             return Results.Ok(new { success = true });
-        });
+        })
+        .WithName("ReportBug");
 
         return group;
     }

--- a/src/Terrarium.Services/Models/DailyStats.cs
+++ b/src/Terrarium.Services/Models/DailyStats.cs
@@ -1,0 +1,9 @@
+namespace Terrarium.Services.Models;
+
+public sealed class DailyStats
+{
+    public int ActivePeers { get; init; }
+    public int SpeciesCount { get; init; }
+    public int TotalPopulation { get; init; }
+    public DateTime? LastRollup { get; init; }
+}

--- a/src/Terrarium.Services/Models/HeartbeatResult.cs
+++ b/src/Terrarium.Services/Models/HeartbeatResult.cs
@@ -1,0 +1,6 @@
+namespace Terrarium.Services.Models;
+
+public sealed class HeartbeatResult
+{
+    public bool Success { get; init; }
+}

--- a/src/Terrarium.Services/Models/PopulationHistoryEntry.cs
+++ b/src/Terrarium.Services/Models/PopulationHistoryEntry.cs
@@ -1,0 +1,16 @@
+namespace Terrarium.Services.Models;
+
+public sealed class PopulationHistoryEntry
+{
+    public DateTime SampleDateTime { get; init; }
+    public string SpeciesName { get; init; } = string.Empty;
+    public int Population { get; init; }
+    public int BirthCount { get; init; }
+    public int StarvedCount { get; init; }
+    public int KilledCount { get; init; }
+    public int ErrorCount { get; init; }
+    public int TimeoutCount { get; init; }
+    public int SickCount { get; init; }
+    public int OldAgeCount { get; init; }
+    public int SecurityViolationCount { get; init; }
+}

--- a/src/Terrarium.Services/Models/PopulationHistoryRow.cs
+++ b/src/Terrarium.Services/Models/PopulationHistoryRow.cs
@@ -1,0 +1,21 @@
+namespace Terrarium.Services.Models;
+
+public sealed class PopulationHistoryRow
+{
+    public Guid Guid { get; init; }
+    public int TickNumber { get; init; }
+    public required string SpeciesName { get; init; }
+    public DateTime ClientTime { get; init; }
+    public int CorrectTime { get; init; }
+    public int Population { get; init; }
+    public int BirthCount { get; init; }
+    public int TeleportedToCount { get; init; }
+    public int StarvedCount { get; init; }
+    public int KilledCount { get; init; }
+    public int TeleportedFromCount { get; init; }
+    public int ErrorCount { get; init; }
+    public int TimeoutCount { get; init; }
+    public int SickCount { get; init; }
+    public int OldAgeCount { get; init; }
+    public int SecurityViolationCount { get; init; }
+}

--- a/src/Terrarium.Services/Models/ReportPopulationResult.cs
+++ b/src/Terrarium.Services/Models/ReportPopulationResult.cs
@@ -1,0 +1,16 @@
+namespace Terrarium.Services.Models;
+
+public enum ReportingReturnCode
+{
+    Success = 0,
+    AlreadyExists = 1,
+    ServerDown = 2,
+    NodeTimedOut = 3,
+    NodeCorrupted = 4,
+    OrganismBlacklisted = 5
+}
+
+public sealed class ReportPopulationResult
+{
+    public ReportingReturnCode ReturnCode { get; init; }
+}

--- a/src/Terrarium.Services/Models/ServerVersionInfo.cs
+++ b/src/Terrarium.Services/Models/ServerVersionInfo.cs
@@ -1,0 +1,7 @@
+namespace Terrarium.Services.Models;
+
+public sealed class ServerVersionInfo
+{
+    public string LatestVersion { get; init; } = string.Empty;
+    public string MOTD { get; init; } = string.Empty;
+}

--- a/src/Terrarium.Services/Models/SpeciesDistributionEntry.cs
+++ b/src/Terrarium.Services/Models/SpeciesDistributionEntry.cs
@@ -1,0 +1,9 @@
+namespace Terrarium.Services.Models;
+
+public sealed class SpeciesDistributionEntry
+{
+    public string SpeciesName { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public string AuthorName { get; init; } = string.Empty;
+    public int Population { get; init; }
+}

--- a/src/Terrarium.Services/Models/SpeciesPopulationData.cs
+++ b/src/Terrarium.Services/Models/SpeciesPopulationData.cs
@@ -1,0 +1,16 @@
+namespace Terrarium.Services.Models;
+
+public sealed class SpeciesPopulationData
+{
+    public DateTime SampleDateTime { get; init; }
+    public string SpeciesName { get; init; } = string.Empty;
+    public int Population { get; init; }
+    public int BirthCount { get; init; }
+    public int StarvedCount { get; init; }
+    public int KilledCount { get; init; }
+    public int ErrorCount { get; init; }
+    public int TimeoutCount { get; init; }
+    public int SickCount { get; init; }
+    public int OldAgeCount { get; init; }
+    public int SecurityViolationCount { get; init; }
+}

--- a/src/Terrarium.Services/Models/SpeciesWithPopulation.cs
+++ b/src/Terrarium.Services/Models/SpeciesWithPopulation.cs
@@ -1,0 +1,11 @@
+namespace Terrarium.Services.Models;
+
+public sealed class SpeciesWithPopulation
+{
+    public string SpeciesName { get; init; } = string.Empty;
+    public string AuthorName { get; init; } = string.Empty;
+    public string AuthorEmail { get; init; } = string.Empty;
+    public string Version { get; init; } = string.Empty;
+    public int Population { get; init; }
+    public string Type { get; init; } = string.Empty;
+}

--- a/src/Terrarium.Services/Models/TopAnimalEntry.cs
+++ b/src/Terrarium.Services/Models/TopAnimalEntry.cs
@@ -1,0 +1,8 @@
+namespace Terrarium.Services.Models;
+
+public sealed class TopAnimalEntry
+{
+    public string Name { get; init; } = string.Empty;
+    public string AuthorName { get; init; } = string.Empty;
+    public int Population { get; init; }
+}

--- a/src/Terrarium.Services/Models/TopCreatureEntry.cs
+++ b/src/Terrarium.Services/Models/TopCreatureEntry.cs
@@ -1,0 +1,10 @@
+namespace Terrarium.Services.Models;
+
+public sealed class TopCreatureEntry
+{
+    public string Name { get; init; } = string.Empty;
+    public string AuthorName { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public int Population { get; init; }
+    public int KilledCount { get; init; }
+}

--- a/src/Terrarium.Services/Models/WatsonReport.cs
+++ b/src/Terrarium.Services/Models/WatsonReport.cs
@@ -1,0 +1,12 @@
+namespace Terrarium.Services.Models;
+
+public sealed class WatsonReport
+{
+    public required string LogType { get; init; }
+    public string? OSVersion { get; init; }
+    public string? GameVersion { get; init; }
+    public string? CLRVersion { get; init; }
+    public required string ErrorLog { get; init; }
+    public string? UserEmail { get; init; }
+    public string? UserComment { get; init; }
+}

--- a/src/Terrarium.Web/Program.cs
+++ b/src/Terrarium.Web/Program.cs
@@ -1,8 +1,15 @@
+using Terrarium.Configuration;
 using Terrarium.Web.Components;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
+builder.Services.AddTerrariumConfiguration();
+
+builder.Services.AddHttpClient("terrarium-server", client =>
+{
+    client.BaseAddress = new Uri("https+http://server");
+});
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();

--- a/src/Terrarium.Web/Terrarium.Web.csproj
+++ b/src/Terrarium.Web/Terrarium.Web.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <ProjectReference Include="..\Terrarium.Configuration\Terrarium.Configuration.csproj" />
     <ProjectReference Include="..\Terrarium.ServiceDefaults\Terrarium.ServiceDefaults.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Sprint 5

Closes #41, #42

- Wire Configuration to Aspire service discovery
- Azure Container Apps Bicep + azure.yaml for azd up

### Changes
- **src/Terrarium.Web/Program.cs**: Added `AddTerrariumConfiguration()` for `IOptions<GameSettings>` and `HttpClient` with Aspire service discovery (`https+http://server`)
- **src/Terrarium.Web/Terrarium.Web.csproj**: Added project reference to `Terrarium.Configuration`
- **infra/main.bicep**: Azure Container Apps Environment, Azure SQL, Server + Web container apps
- **azure.yaml**: Azure Developer CLI manifest for `azd up`