### PR TITLE
Complete Terrarium.Services clients

### DIFF
--- a/src/Terrarium.Services/Clients/ChartServiceClient.cs
+++ b/src/Terrarium.Services/Clients/ChartServiceClient.cs
@@ -6,43 +6,39 @@ namespace Terrarium.Services.Clients;
 
 public sealed class ChartServiceClient(HttpClient httpClient) : IChartService
 {
-    public async Task<IReadOnlyList<SpeciesInfo>> GetSpeciesListAsync(CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<PopulationHistoryEntry>> GetPopulationHistoryAsync(string species,
+        DateTime? beginDate = null, DateTime? endDate = null,
+        CancellationToken cancellationToken = default)
     {
-        var result = await httpClient.GetFromJsonAsync<List<SpeciesInfo>>("charts/species", cancellationToken);
+        var url = $"charts/population-history?species={Uri.EscapeDataString(species)}";
+        if (beginDate.HasValue)
+            url += $"&beginDate={beginDate.Value:O}";
+        if (endDate.HasValue)
+            url += $"&endDate={endDate.Value:O}";
+
+        var result = await httpClient.GetFromJsonAsync<List<PopulationHistoryEntry>>(url, cancellationToken);
         return result ?? [];
     }
 
-    public async Task<string> ChartPopulationAsync(DateTime start, DateTime end, IReadOnlyList<string> speciesNames,
+    public async Task<IReadOnlyList<SpeciesDistributionEntry>> GetSpeciesDistributionAsync(
         CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync("charts/population",
-            new { start, end, speciesNames }, cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
-    }
-
-    public async Task<string> ChartVitalsAsync(DateTime start, DateTime end, string species,
-        CancellationToken cancellationToken = default)
-    {
-        var response = await httpClient.GetAsync(
-            $"charts/vitals?start={start:O}&end={end:O}&species={Uri.EscapeDataString(species)}", cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
-    }
-
-    public async Task<IReadOnlyList<SpeciesInfo>> GrabLatestSpeciesDataAsync(string species,
-        CancellationToken cancellationToken = default)
-    {
-        var result = await httpClient.GetFromJsonAsync<List<SpeciesInfo>>(
-            $"charts/species/{Uri.EscapeDataString(species)}/latest", cancellationToken);
+        var result = await httpClient.GetFromJsonAsync<List<SpeciesDistributionEntry>>(
+            "charts/species-distribution", cancellationToken);
         return result ?? [];
     }
 
-    public async Task<IReadOnlyList<SpeciesInfo>> GetTopAnimalsAsync(string version, OrganismType type, int count,
+    public async Task<IReadOnlyList<TopCreatureEntry>> GetTopCreaturesAsync(string version,
+        string? type = null, int? count = null,
         CancellationToken cancellationToken = default)
     {
-        var result = await httpClient.GetFromJsonAsync<List<SpeciesInfo>>(
-            $"charts/top?version={Uri.EscapeDataString(version)}&type={type}&count={count}", cancellationToken);
+        var url = $"charts/top-creatures?version={Uri.EscapeDataString(version)}";
+        if (type is not null)
+            url += $"&type={Uri.EscapeDataString(type)}";
+        if (count.HasValue)
+            url += $"&count={count.Value}";
+
+        var result = await httpClient.GetFromJsonAsync<List<TopCreatureEntry>>(url, cancellationToken);
         return result ?? [];
     }
 }

--- a/src/Terrarium.Services/Clients/MessagingServiceClient.cs
+++ b/src/Terrarium.Services/Clients/MessagingServiceClient.cs
@@ -7,22 +7,29 @@ public sealed class MessagingServiceClient(HttpClient httpClient) : IMessagingSe
 {
     public async Task<string> GetWelcomeMessageAsync(CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.GetAsync("messaging/welcome", cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+        var result = await httpClient.GetFromJsonAsync<MessageResponse>("messaging/welcome", cancellationToken);
+        return result?.Message ?? string.Empty;
     }
 
     public async Task<string> GetMessageOfTheDayAsync(CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.GetAsync("messaging/motd", cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+        var result = await httpClient.GetFromJsonAsync<MessageResponse>("messaging/motd", cancellationToken);
+        return result?.Message ?? string.Empty;
     }
 
     public async Task<string> GetLatestVersionAsync(CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.GetAsync("messaging/version", cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+        var result = await httpClient.GetFromJsonAsync<VersionResponse>("messaging/version", cancellationToken);
+        return result?.Version ?? string.Empty;
+    }
+
+    private sealed class MessageResponse
+    {
+        public string? Message { get; init; }
+    }
+
+    private sealed class VersionResponse
+    {
+        public string? Version { get; init; }
     }
 }

--- a/src/Terrarium.Services/Clients/PeerDiscoveryServiceClient.cs
+++ b/src/Terrarium.Services/Clients/PeerDiscoveryServiceClient.cs
@@ -8,38 +8,91 @@ public sealed class PeerDiscoveryServiceClient(HttpClient httpClient) : IPeerDis
 {
     public async Task<bool> RegisterUserAsync(string email, CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync("discovery/register-user", new { email }, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("discovery/register-user",
+            new { email }, cancellationToken);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<bool>(cancellationToken);
+        var result = await response.Content.ReadFromJsonAsync<SuccessResponse>(cancellationToken);
+        return result?.Success ?? false;
     }
 
     public async Task<int> GetNumPeersAsync(string version, string channel, CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.GetAsync($"discovery/peers/count?version={Uri.EscapeDataString(version)}&channel={Uri.EscapeDataString(channel)}", cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<int>(cancellationToken);
+        var result = await httpClient.GetFromJsonAsync<PeerCountResponse>(
+            $"discovery/peers?version={Uri.EscapeDataString(version)}&channel={Uri.EscapeDataString(channel)}", cancellationToken);
+        return result?.Count ?? 0;
     }
 
     public async Task<string> ValidatePeerAsync(CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.GetAsync("discovery/validate", cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync(cancellationToken) ?? string.Empty;
+        var result = await httpClient.GetFromJsonAsync<ValidateResponse>(
+            "discovery/validate", cancellationToken);
+        return result?.IpAddress ?? string.Empty;
     }
 
     public async Task<PeerRegistrationResult> RegisterPeerAsync(string version, string channel, Guid peerGuid, CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync("discovery/register", new { version, channel, peerGuid }, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("discovery/register",
+            new { version, channel, guid = peerGuid }, cancellationToken);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<PeerRegistrationResult>(cancellationToken)
-            ?? new PeerRegistrationResult { Status = RegisterPeerResult.Failure };
+        var result = await response.Content.ReadFromJsonAsync<RegisterPeerResponse>(cancellationToken);
+        if (result is null)
+            return new PeerRegistrationResult { Status = RegisterPeerResult.Failure };
+
+        return new PeerRegistrationResult
+        {
+            Status = result.Result,
+            PeerCount = result.PeerCount,
+            Peers = result.Peers?.Select(p => new PeerInfo
+            {
+                IPAddress = p.IPAddress,
+                Version = version,
+                LastContact = p.Lease
+            }).ToList() ?? []
+        };
     }
 
     public async Task<VersionCheckResult> IsVersionDisabledAsync(string version, CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.GetAsync($"discovery/version-check?version={Uri.EscapeDataString(version)}", cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<VersionCheckResult>(cancellationToken)
-            ?? new VersionCheckResult { IsDisabled = true, ErrorMessage = "Failed to check version status" };
+        var result = await httpClient.GetFromJsonAsync<VersionCheckResponse>(
+            $"discovery/version-check?version={Uri.EscapeDataString(version)}", cancellationToken);
+        return new VersionCheckResult
+        {
+            IsDisabled = result?.Disabled ?? true,
+            ErrorMessage = result?.Message
+        };
+    }
+
+    private sealed class SuccessResponse
+    {
+        public bool Success { get; init; }
+    }
+
+    private sealed class PeerCountResponse
+    {
+        public int Count { get; init; }
+    }
+
+    private sealed class ValidateResponse
+    {
+        public string? IpAddress { get; init; }
+    }
+
+    private sealed class RegisterPeerResponse
+    {
+        public RegisterPeerResult Result { get; init; }
+        public int PeerCount { get; init; }
+        public List<PeerEntry>? Peers { get; init; }
+    }
+
+    private sealed class PeerEntry
+    {
+        public string IPAddress { get; init; } = string.Empty;
+        public DateTime Lease { get; init; }
+    }
+
+    private sealed class VersionCheckResponse
+    {
+        public bool Disabled { get; init; }
+        public string? Message { get; init; }
     }
 }

--- a/src/Terrarium.Services/Clients/PopulationServiceClient.cs
+++ b/src/Terrarium.Services/Clients/PopulationServiceClient.cs
@@ -6,10 +6,14 @@ namespace Terrarium.Services.Clients;
 
 public sealed class PopulationServiceClient(HttpClient httpClient) : IPopulationService
 {
-    public async Task<int> ReportPopulationAsync(PopulationData data, CancellationToken cancellationToken = default)
+    public async Task<ReportPopulationResult> ReportPopulationAsync(Guid peerGuid, int currentTick,
+        IReadOnlyList<PopulationHistoryRow> history,
+        CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync("population/report", data, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("reporting/population",
+            new { guid = peerGuid, currentTick, history }, cancellationToken);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<int>(cancellationToken);
+        return await response.Content.ReadFromJsonAsync<ReportPopulationResult>(cancellationToken)
+            ?? new ReportPopulationResult { ReturnCode = ReportingReturnCode.ServerDown };
     }
 }

--- a/src/Terrarium.Services/Clients/ReportingServiceClient.cs
+++ b/src/Terrarium.Services/Clients/ReportingServiceClient.cs
@@ -6,21 +6,53 @@ namespace Terrarium.Services.Clients;
 
 public sealed class ReportingServiceClient(HttpClient httpClient) : IReportingService
 {
-    public async Task ReportBugAsync(BugReport report, CancellationToken cancellationToken = default)
+    public async Task<bool> ReportBugAsync(BugReport report, CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync("reporting/bugs", report, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("bugs/report", report, cancellationToken);
         response.EnsureSuccessStatusCode();
+        var result = await response.Content.ReadFromJsonAsync<SuccessResponse>(cancellationToken);
+        return result?.Success ?? false;
     }
 
-    public async Task ReportErrorAsync(string errorData, CancellationToken cancellationToken = default)
+    public async Task<ReportPopulationResult> ReportPopulationAsync(Guid peerGuid, int currentTick,
+        IReadOnlyList<PopulationHistoryRow> history,
+        CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync("reporting/errors", new { errorData }, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("reporting/population",
+            new { guid = peerGuid, currentTick, history }, cancellationToken);
         response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<ReportPopulationResult>(cancellationToken)
+            ?? new ReportPopulationResult { ReturnCode = ReportingReturnCode.ServerDown };
     }
 
-    public async Task ReportUsageAsync(UsageData data, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<SpeciesWithPopulation>> GetSpeciesListAsync(
+        CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync("reporting/usage", data, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        var result = await httpClient.GetFromJsonAsync<List<SpeciesWithPopulation>>(
+            "reporting/stats/species-list", cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<IReadOnlyList<SpeciesPopulationData>> GetLatestSpeciesDataAsync(string species,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<List<SpeciesPopulationData>>(
+            $"reporting/stats/latest?species={Uri.EscapeDataString(species)}", cancellationToken);
+        return result ?? [];
+    }
+
+    public async Task<IReadOnlyList<TopAnimalEntry>> GetTopAnimalsAsync(string version, string type, int? count,
+        CancellationToken cancellationToken = default)
+    {
+        var url = $"reporting/stats/top-animals?version={Uri.EscapeDataString(version)}&type={Uri.EscapeDataString(type)}";
+        if (count.HasValue)
+            url += $"&count={count.Value}";
+        var result = await httpClient.GetFromJsonAsync<List<TopAnimalEntry>>(url, cancellationToken);
+        return result ?? [];
+    }
+
+    private sealed class SuccessResponse
+    {
+        public bool Success { get; init; }
     }
 }

--- a/src/Terrarium.Services/Clients/SpeciesServiceClient.cs
+++ b/src/Terrarium.Services/Clients/SpeciesServiceClient.cs
@@ -10,7 +10,7 @@ public sealed class SpeciesServiceClient(HttpClient httpClient) : ISpeciesServic
         string email, string assemblyFullName, byte[] assemblyCode,
         CancellationToken cancellationToken = default)
     {
-        var payload = new
+        var response = await httpClient.PostAsJsonAsync("species/register", new
         {
             name,
             version,
@@ -18,12 +18,11 @@ public sealed class SpeciesServiceClient(HttpClient httpClient) : ISpeciesServic
             author,
             email,
             assemblyFullName,
-            assemblyCode = Convert.ToBase64String(assemblyCode)
-        };
-
-        var response = await httpClient.PostAsJsonAsync("species", payload, cancellationToken);
+            assemblyCode
+        }, cancellationToken);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<SpeciesServiceStatus>(cancellationToken);
+        var result = await response.Content.ReadFromJsonAsync<RegisterSpeciesResponse>(cancellationToken);
+        return result?.Status ?? SpeciesServiceStatus.ServerDown;
     }
 
     public async Task<IReadOnlyList<SpeciesInfo>> GetExtinctSpeciesAsync(string version, string filter,
@@ -38,7 +37,7 @@ public sealed class SpeciesServiceClient(HttpClient httpClient) : ISpeciesServic
         CancellationToken cancellationToken = default)
     {
         var result = await httpClient.GetFromJsonAsync<List<SpeciesInfo>>(
-            $"species?version={Uri.EscapeDataString(version)}&filter={Uri.EscapeDataString(filter)}", cancellationToken);
+            $"species/list?version={Uri.EscapeDataString(version)}&filter={Uri.EscapeDataString(filter)}", cancellationToken);
         return result ?? [];
     }
 
@@ -54,16 +53,31 @@ public sealed class SpeciesServiceClient(HttpClient httpClient) : ISpeciesServic
     public async Task<byte[]> ReintroduceSpeciesAsync(string name, string version, Guid peerGuid,
         CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.PostAsJsonAsync(
-            $"species/{Uri.EscapeDataString(name)}/reintroduce",
-            new { version, peerGuid }, cancellationToken);
+        var response = await httpClient.PostAsJsonAsync("species/reintroduce", new
+        {
+            name,
+            version,
+            peerGuid
+        }, cancellationToken);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsByteArrayAsync(cancellationToken);
+        var result = await response.Content.ReadFromJsonAsync<ReintroduceResponse>(cancellationToken);
+        return result?.AssemblyCode ?? [];
     }
 
     public async Task<IReadOnlyList<string>> GetBlacklistedSpeciesAsync(CancellationToken cancellationToken = default)
     {
         var result = await httpClient.GetFromJsonAsync<List<string>>("species/blacklisted", cancellationToken);
         return result ?? [];
+    }
+
+    private sealed class RegisterSpeciesResponse
+    {
+        public SpeciesServiceStatus Status { get; init; }
+    }
+
+    private sealed class ReintroduceResponse
+    {
+        public bool Success { get; init; }
+        public byte[]? AssemblyCode { get; init; }
     }
 }

--- a/src/Terrarium.Services/Clients/UsageServiceClient.cs
+++ b/src/Terrarium.Services/Clients/UsageServiceClient.cs
@@ -1,0 +1,30 @@
+using System.Net.Http.Json;
+using Terrarium.Services.Interfaces;
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Clients;
+
+public sealed class UsageServiceClient(HttpClient httpClient) : IUsageService
+{
+    public async Task<HeartbeatResult> SendHeartbeatAsync(Guid peerGuid, int currentTick,
+        CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("usage/heartbeat",
+            new { guid = peerGuid, currentTick }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<HeartbeatResult>(cancellationToken)
+            ?? new HeartbeatResult { Success = false };
+    }
+
+    public async Task<DailyStats> GetDailyStatsAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<DailyStats>("usage/daily-stats", cancellationToken);
+        return result ?? new DailyStats();
+    }
+
+    public async Task<ServerVersionInfo> GetServerVersionAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await httpClient.GetFromJsonAsync<ServerVersionInfo>("usage/version-check", cancellationToken);
+        return result ?? new ServerVersionInfo();
+    }
+}

--- a/src/Terrarium.Services/Clients/WatsonServiceClient.cs
+++ b/src/Terrarium.Services/Clients/WatsonServiceClient.cs
@@ -1,0 +1,31 @@
+using System.Net.Http.Json;
+using Terrarium.Services.Interfaces;
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Clients;
+
+public sealed class WatsonServiceClient(HttpClient httpClient) : IWatsonService
+{
+    public async Task<bool> ReportErrorAsync(WatsonReport report, CancellationToken cancellationToken = default)
+    {
+        var response = await httpClient.PostAsJsonAsync("watson/report", new
+        {
+            report.LogType,
+            report.OSVersion,
+            report.GameVersion,
+            clrVersion = report.CLRVersion,
+            report.ErrorLog,
+            report.UserEmail,
+            report.UserComment
+        }, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<SuccessResponse>(cancellationToken);
+        return result?.Success ?? false;
+    }
+
+    private sealed class SuccessResponse
+    {
+        public bool Success { get; init; }
+    }
+}

--- a/src/Terrarium.Services/Interfaces/IChartService.cs
+++ b/src/Terrarium.Services/Interfaces/IChartService.cs
@@ -4,17 +4,14 @@ namespace Terrarium.Services.Interfaces;
 
 public interface IChartService
 {
-    Task<IReadOnlyList<SpeciesInfo>> GetSpeciesListAsync(CancellationToken cancellationToken = default);
-
-    Task<string> ChartPopulationAsync(DateTime start, DateTime end, IReadOnlyList<string> speciesNames,
+    Task<IReadOnlyList<PopulationHistoryEntry>> GetPopulationHistoryAsync(string species,
+        DateTime? beginDate = null, DateTime? endDate = null,
         CancellationToken cancellationToken = default);
 
-    Task<string> ChartVitalsAsync(DateTime start, DateTime end, string species,
+    Task<IReadOnlyList<SpeciesDistributionEntry>> GetSpeciesDistributionAsync(
         CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyList<SpeciesInfo>> GrabLatestSpeciesDataAsync(string species,
-        CancellationToken cancellationToken = default);
-
-    Task<IReadOnlyList<SpeciesInfo>> GetTopAnimalsAsync(string version, OrganismType type, int count,
+    Task<IReadOnlyList<TopCreatureEntry>> GetTopCreaturesAsync(string version,
+        string? type = null, int? count = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/Terrarium.Services/Interfaces/IPopulationService.cs
+++ b/src/Terrarium.Services/Interfaces/IPopulationService.cs
@@ -4,5 +4,7 @@ namespace Terrarium.Services.Interfaces;
 
 public interface IPopulationService
 {
-    Task<int> ReportPopulationAsync(PopulationData data, CancellationToken cancellationToken = default);
+    Task<ReportPopulationResult> ReportPopulationAsync(Guid peerGuid, int currentTick,
+        IReadOnlyList<PopulationHistoryRow> history,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Terrarium.Services/Interfaces/IReportingService.cs
+++ b/src/Terrarium.Services/Interfaces/IReportingService.cs
@@ -4,7 +4,18 @@ namespace Terrarium.Services.Interfaces;
 
 public interface IReportingService
 {
-    Task ReportBugAsync(BugReport report, CancellationToken cancellationToken = default);
-    Task ReportErrorAsync(string errorData, CancellationToken cancellationToken = default);
-    Task ReportUsageAsync(UsageData data, CancellationToken cancellationToken = default);
+    Task<bool> ReportBugAsync(BugReport report, CancellationToken cancellationToken = default);
+
+    Task<ReportPopulationResult> ReportPopulationAsync(Guid peerGuid, int currentTick,
+        IReadOnlyList<PopulationHistoryRow> history,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SpeciesWithPopulation>> GetSpeciesListAsync(
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<SpeciesPopulationData>> GetLatestSpeciesDataAsync(string species,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<TopAnimalEntry>> GetTopAnimalsAsync(string version, string type, int? count,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Terrarium.Services/Interfaces/IUsageService.cs
+++ b/src/Terrarium.Services/Interfaces/IUsageService.cs
@@ -1,0 +1,13 @@
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Interfaces;
+
+public interface IUsageService
+{
+    Task<HeartbeatResult> SendHeartbeatAsync(Guid peerGuid, int currentTick,
+        CancellationToken cancellationToken = default);
+
+    Task<DailyStats> GetDailyStatsAsync(CancellationToken cancellationToken = default);
+
+    Task<ServerVersionInfo> GetServerVersionAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Terrarium.Services/Interfaces/IWatsonService.cs
+++ b/src/Terrarium.Services/Interfaces/IWatsonService.cs
@@ -1,0 +1,8 @@
+using Terrarium.Services.Models;
+
+namespace Terrarium.Services.Interfaces;
+
+public interface IWatsonService
+{
+    Task<bool> ReportErrorAsync(WatsonReport report, CancellationToken cancellationToken = default);
+}

--- a/src/Terrarium.Services/Models/DailyStats.cs
+++ b/src/Terrarium.Services/Models/DailyStats.cs
@@ -1,0 +1,9 @@
+namespace Terrarium.Services.Models;
+
+public sealed class DailyStats
+{
+    public int ActivePeers { get; init; }
+    public int SpeciesCount { get; init; }
+    public int TotalPopulation { get; init; }
+    public DateTime? LastRollup { get; init; }
+}

--- a/src/Terrarium.Services/Models/HeartbeatResult.cs
+++ b/src/Terrarium.Services/Models/HeartbeatResult.cs
@@ -1,0 +1,6 @@
+namespace Terrarium.Services.Models;
+
+public sealed class HeartbeatResult
+{
+    public bool Success { get; init; }
+}

--- a/src/Terrarium.Services/Models/PopulationHistoryEntry.cs
+++ b/src/Terrarium.Services/Models/PopulationHistoryEntry.cs
@@ -1,0 +1,16 @@
+namespace Terrarium.Services.Models;
+
+public sealed class PopulationHistoryEntry
+{
+    public DateTime SampleDateTime { get; init; }
+    public string SpeciesName { get; init; } = string.Empty;
+    public int Population { get; init; }
+    public int BirthCount { get; init; }
+    public int StarvedCount { get; init; }
+    public int KilledCount { get; init; }
+    public int ErrorCount { get; init; }
+    public int TimeoutCount { get; init; }
+    public int SickCount { get; init; }
+    public int OldAgeCount { get; init; }
+    public int SecurityViolationCount { get; init; }
+}

--- a/src/Terrarium.Services/Models/PopulationHistoryRow.cs
+++ b/src/Terrarium.Services/Models/PopulationHistoryRow.cs
@@ -1,0 +1,21 @@
+namespace Terrarium.Services.Models;
+
+public sealed class PopulationHistoryRow
+{
+    public Guid Guid { get; init; }
+    public int TickNumber { get; init; }
+    public required string SpeciesName { get; init; }
+    public DateTime ClientTime { get; init; }
+    public int CorrectTime { get; init; }
+    public int Population { get; init; }
+    public int BirthCount { get; init; }
+    public int TeleportedToCount { get; init; }
+    public int StarvedCount { get; init; }
+    public int KilledCount { get; init; }
+    public int TeleportedFromCount { get; init; }
+    public int ErrorCount { get; init; }
+    public int TimeoutCount { get; init; }
+    public int SickCount { get; init; }
+    public int OldAgeCount { get; init; }
+    public int SecurityViolationCount { get; init; }
+}

--- a/src/Terrarium.Services/Models/ReportPopulationResult.cs
+++ b/src/Terrarium.Services/Models/ReportPopulationResult.cs
@@ -1,0 +1,16 @@
+namespace Terrarium.Services.Models;
+
+public enum ReportingReturnCode
+{
+    Success = 0,
+    AlreadyExists = 1,
+    ServerDown = 2,
+    NodeTimedOut = 3,
+    NodeCorrupted = 4,
+    OrganismBlacklisted = 5
+}
+
+public sealed class ReportPopulationResult
+{
+    public ReportingReturnCode ReturnCode { get; init; }
+}

--- a/src/Terrarium.Services/Models/ServerVersionInfo.cs
+++ b/src/Terrarium.Services/Models/ServerVersionInfo.cs
@@ -1,0 +1,7 @@
+namespace Terrarium.Services.Models;
+
+public sealed class ServerVersionInfo
+{
+    public string LatestVersion { get; init; } = string.Empty;
+    public string MOTD { get; init; } = string.Empty;
+}

--- a/src/Terrarium.Services/Models/SpeciesDistributionEntry.cs
+++ b/src/Terrarium.Services/Models/SpeciesDistributionEntry.cs
@@ -1,0 +1,9 @@
+namespace Terrarium.Services.Models;
+
+public sealed class SpeciesDistributionEntry
+{
+    public string SpeciesName { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public string AuthorName { get; init; } = string.Empty;
+    public int Population { get; init; }
+}

--- a/src/Terrarium.Services/Models/SpeciesPopulationData.cs
+++ b/src/Terrarium.Services/Models/SpeciesPopulationData.cs
@@ -1,0 +1,16 @@
+namespace Terrarium.Services.Models;
+
+public sealed class SpeciesPopulationData
+{
+    public DateTime SampleDateTime { get; init; }
+    public string SpeciesName { get; init; } = string.Empty;
+    public int Population { get; init; }
+    public int BirthCount { get; init; }
+    public int StarvedCount { get; init; }
+    public int KilledCount { get; init; }
+    public int ErrorCount { get; init; }
+    public int TimeoutCount { get; init; }
+    public int SickCount { get; init; }
+    public int OldAgeCount { get; init; }
+    public int SecurityViolationCount { get; init; }
+}

--- a/src/Terrarium.Services/Models/SpeciesWithPopulation.cs
+++ b/src/Terrarium.Services/Models/SpeciesWithPopulation.cs
@@ -1,0 +1,11 @@
+namespace Terrarium.Services.Models;
+
+public sealed class SpeciesWithPopulation
+{
+    public string SpeciesName { get; init; } = string.Empty;
+    public string AuthorName { get; init; } = string.Empty;
+    public string AuthorEmail { get; init; } = string.Empty;
+    public string Version { get; init; } = string.Empty;
+    public int Population { get; init; }
+    public string Type { get; init; } = string.Empty;
+}

--- a/src/Terrarium.Services/Models/TopAnimalEntry.cs
+++ b/src/Terrarium.Services/Models/TopAnimalEntry.cs
@@ -1,0 +1,8 @@
+namespace Terrarium.Services.Models;
+
+public sealed class TopAnimalEntry
+{
+    public string Name { get; init; } = string.Empty;
+    public string AuthorName { get; init; } = string.Empty;
+    public int Population { get; init; }
+}

--- a/src/Terrarium.Services/Models/TopCreatureEntry.cs
+++ b/src/Terrarium.Services/Models/TopCreatureEntry.cs
@@ -1,0 +1,10 @@
+namespace Terrarium.Services.Models;
+
+public sealed class TopCreatureEntry
+{
+    public string Name { get; init; } = string.Empty;
+    public string AuthorName { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public int Population { get; init; }
+    public int KilledCount { get; init; }
+}

--- a/src/Terrarium.Services/Models/WatsonReport.cs
+++ b/src/Terrarium.Services/Models/WatsonReport.cs
@@ -1,0 +1,12 @@
+namespace Terrarium.Services.Models;
+
+public sealed class WatsonReport
+{
+    public required string LogType { get; init; }
+    public string? OSVersion { get; init; }
+    public string? GameVersion { get; init; }
+    public string? CLRVersion { get; init; }
+    public required string ErrorLog { get; init; }
+    public string? UserEmail { get; init; }
+    public string? UserComment { get; init; }
+}

--- a/src/Terrarium.Services/ServiceCollectionExtensions.cs
+++ b/src/Terrarium.Services/ServiceCollectionExtensions.cs
@@ -30,6 +30,12 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient<IChartService, ChartServiceClient>(client =>
             client.BaseAddress = new Uri(baseAddress, "api/"));
 
+        services.AddHttpClient<IUsageService, UsageServiceClient>(client =>
+            client.BaseAddress = new Uri(baseAddress, "api/"));
+
+        services.AddHttpClient<IWatsonService, WatsonServiceClient>(client =>
+            client.BaseAddress = new Uri(baseAddress, "api/"));
+
         return services;
     }
 

--- a/src/Terrarium.sln
+++ b/src/Terrarium.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SimplePlant", "Terrarium.Sa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terrarium.Game.Tests", "Terrarium.Game.Tests\Terrarium.Game.Tests.csproj", "{20BBC683-A1A3-474C-B9CF-28EB0C1C640A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Terrarium.Services", "Terrarium.Services\Terrarium.Services.csproj", "{7D673282-F667-448C-B84B-9A4FBCBC5C26}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -211,6 +213,18 @@ Global
 		{20BBC683-A1A3-474C-B9CF-28EB0C1C640A}.Release|x64.Build.0 = Release|Any CPU
 		{20BBC683-A1A3-474C-B9CF-28EB0C1C640A}.Release|x86.ActiveCfg = Release|Any CPU
 		{20BBC683-A1A3-474C-B9CF-28EB0C1C640A}.Release|x86.Build.0 = Release|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Debug|x64.Build.0 = Debug|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Debug|x86.Build.0 = Debug|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Release|x64.ActiveCfg = Release|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Release|x64.Build.0 = Release|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Release|x86.ActiveCfg = Release|Any CPU
+		{7D673282-F667-448C-B84B-9A4FBCBC5C26}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Sprint 5

Closes #37

Updates all service clients to cover every server endpoint.

### Changes
- Updated IChartService and ChartServiceClient to match /api/charts/* endpoints (population-history, species-distribution, top-creatures)
- Updated IReportingService and ReportingServiceClient to match /api/reporting/* and /api/bugs/* endpoints
- Updated IPopulationService and PopulationServiceClient to match /api/reporting/population endpoint
- Updated SpeciesServiceClient URLs to match /api/species/* endpoints (register, list, reintroduce)
- Updated PeerDiscoveryServiceClient to parse JSON responses from /api/discovery/* endpoints
- Updated MessagingServiceClient to parse JSON responses
- Added IWatsonService and WatsonServiceClient for /api/watson/report endpoint
- Added IUsageService and UsageServiceClient for /api/usage/* endpoints (heartbeat, daily-stats, version-check)
- Added 12 new model classes matching server DTOs
- Registered all new service clients in ServiceCollectionExtensions
- Added Terrarium.Services project to solution