### PR TITLE
E2E integration tests

### DIFF
--- a/src/Terrarium.Game.Tests/GameEngineTests.cs
+++ b/src/Terrarium.Game.Tests/GameEngineTests.cs
@@ -1,0 +1,228 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using OrganismBase;
+using Xunit;
+
+namespace Terrarium.Game.Tests;
+
+/// <summary>
+/// Tests for GameEngine: initialization, tick execution, and world vector management.
+/// </summary>
+public class GameEngineTests
+{
+    private static GameEngine CreateEngine(
+        int worldWidth = 2048,
+        int worldHeight = 2048,
+        int maxAnimals = 50,
+        int maxPlants = 50)
+    {
+        var logger = NullLogger<GameEngine>.Instance;
+        var popLogger = NullLogger<PopulationData>.Instance;
+        var populationData = new PopulationData(false, popLogger);
+
+        return new GameEngine(logger, populationData,
+            worldWidth, worldHeight, maxAnimals, maxPlants);
+    }
+
+    // --- Initialization ---
+
+    [Fact]
+    public void GameEngine_CanBeCreated()
+    {
+        var engine = CreateEngine();
+        Assert.NotNull(engine);
+    }
+
+    [Fact]
+    public void GameEngine_HasCorrectDimensions()
+    {
+        var engine = CreateEngine(2048, 2048);
+        Assert.Equal(2048, engine.WorldWidth);
+        Assert.Equal(2048, engine.WorldHeight);
+    }
+
+    [Fact]
+    public void GameEngine_HasCorrectMaxCounts()
+    {
+        var engine = CreateEngine(maxAnimals: 100, maxPlants: 75);
+        Assert.Equal(100, engine.MaxAnimals);
+        Assert.Equal(75, engine.MaxPlants);
+    }
+
+    [Fact]
+    public void GameEngine_StartsAtPhaseZero()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(0, engine.TurnPhase);
+    }
+
+    [Fact]
+    public void GameEngine_StartsWithZeroCounts()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(0, engine.AnimalCount);
+        Assert.Equal(0, engine.PlantCount);
+    }
+
+    [Fact]
+    public void GameEngine_HasCurrentVector()
+    {
+        var engine = CreateEngine();
+        Assert.NotNull(engine.CurrentVector);
+    }
+
+    [Fact]
+    public void GameEngine_CurrentVector_HasImmutableState()
+    {
+        var engine = CreateEngine();
+        Assert.True(engine.CurrentVector!.State.IsImmutable);
+    }
+
+    [Fact]
+    public void GameEngine_CurrentVector_StartsAtTickZero()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(0, engine.CurrentVector!.State.TickNumber);
+    }
+
+    [Fact]
+    public void GameEngine_HasPopulationData()
+    {
+        var engine = CreateEngine();
+        Assert.NotNull(engine.PopulationData);
+    }
+
+    [Fact]
+    public void GameEngine_DefaultNotEcosystemMode()
+    {
+        var engine = CreateEngine();
+        Assert.False(engine.EcosystemMode);
+    }
+
+    // --- Grid dimensions ---
+
+    [Fact]
+    public void GameEngine_GridWidth_IsDerivedFromWorldWidth()
+    {
+        var engine = CreateEngine(2048, 2048);
+        Assert.True(engine.GridWidth > 0);
+        Assert.Equal(engine.WorldWidth >> EngineSettings.GridWidthPowerOfTwo, engine.GridWidth);
+    }
+
+    [Fact]
+    public void GameEngine_GridHeight_IsDerivedFromWorldHeight()
+    {
+        var engine = CreateEngine(2048, 2048);
+        Assert.True(engine.GridHeight > 0);
+        Assert.Equal(engine.WorldHeight >> EngineSettings.GridHeightPowerOfTwo, engine.GridHeight);
+    }
+
+    // --- ProcessTurn ---
+
+    [Fact]
+    public void ProcessTurn_AdvancesPhase()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(0, engine.TurnPhase);
+
+        var complete = engine.ProcessTurn();
+        Assert.False(complete);
+        Assert.Equal(1, engine.TurnPhase);
+    }
+
+    [Fact]
+    public void ProcessTurn_TenCalls_CompletesOneTick()
+    {
+        var engine = CreateEngine();
+        bool complete = false;
+
+        for (int i = 0; i < 10; i++)
+        {
+            complete = engine.ProcessTurn();
+        }
+
+        Assert.True(complete);
+        Assert.Equal(0, engine.TurnPhase); // resets after full tick
+    }
+
+    [Fact]
+    public void ProcessTurn_AfterFullTick_TickNumberIncrements()
+    {
+        var engine = CreateEngine();
+        Assert.Equal(0, engine.CurrentVector!.State.TickNumber);
+
+        for (int i = 0; i < 10; i++)
+            engine.ProcessTurn();
+
+        Assert.Equal(1, engine.CurrentVector!.State.TickNumber);
+    }
+
+    [Fact]
+    public void ProcessTurn_MultipleFullTicks_IncrementCorrectly()
+    {
+        var engine = CreateEngine();
+
+        for (int tick = 0; tick < 3; tick++)
+            for (int phase = 0; phase < 10; phase++)
+                engine.ProcessTurn();
+
+        Assert.Equal(3, engine.CurrentVector!.State.TickNumber);
+    }
+
+    [Fact]
+    public void ProcessTurn_NineCallsDoNotComplete()
+    {
+        var engine = CreateEngine();
+        bool complete = false;
+
+        for (int i = 0; i < 9; i++)
+            complete = engine.ProcessTurn();
+
+        Assert.False(complete);
+        Assert.Equal(9, engine.TurnPhase);
+    }
+
+    // --- WorldVectorChanged event ---
+
+    [Fact]
+    public void WorldVectorChanged_FiresAfterFullTick()
+    {
+        var engine = CreateEngine();
+        var fired = false;
+        engine.WorldVectorChanged += (_, _) => fired = true;
+
+        for (int i = 0; i < 10; i++)
+            engine.ProcessTurn();
+
+        Assert.True(fired);
+    }
+
+    // --- StopGame ---
+
+    [Fact]
+    public void StopGame_ClearsPopulationData()
+    {
+        var engine = CreateEngine();
+        engine.StopGame(false);
+        Assert.Null(engine.PopulationData);
+    }
+
+    [Fact]
+    public void StopGame_WithSerialize_DoesNotThrow()
+    {
+        var engine = CreateEngine();
+        var ex = Record.Exception(() => engine.StopGame(true));
+        Assert.Null(ex);
+    }
+
+    // --- World dimension normalization ---
+
+    [Fact]
+    public void GameEngine_NormalizesWorldDimensions_ToGridCellBoundaries()
+    {
+        // If dimensions aren't multiples of grid cell size, they get rounded up
+        var engine = CreateEngine(2049, 2049);
+        Assert.Equal(0, engine.WorldWidth % EngineSettings.GridCellWidth);
+        Assert.Equal(0, engine.WorldHeight % EngineSettings.GridCellHeight);
+    }
+}

--- a/src/Terrarium.Game.Tests/SpeciesTests.cs
+++ b/src/Terrarium.Game.Tests/SpeciesTests.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using OrganismBase;
+using Xunit;
+
+namespace Terrarium.Game.Tests;
+
+/// <summary>
+/// Tests for Species: attribute reading, assembly parsing, and species creation.
+/// Uses sample assemblies (SimpleCarnivore, SimpleHerbivore) for integration tests.
+/// </summary>
+public class SpeciesTests
+{
+    // --- GetSpeciesFromAssembly ---
+
+    [Fact]
+    public void GetSpeciesFromAssembly_SimpleCarnivore_ReturnsAnimalSpecies()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.NotNull(species);
+        Assert.IsType<AnimalSpecies>(species);
+    }
+
+    [Fact]
+    public void GetSpeciesFromAssembly_SimpleCarnivore_HasAuthorName()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.False(string.IsNullOrEmpty(species.AuthorName));
+    }
+
+    [Fact]
+    public void GetSpeciesFromAssembly_SimpleCarnivore_HasMatureRadius()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.MatureRadius > 0);
+    }
+
+    [Fact]
+    public void GetSpeciesFromAssembly_SimpleCarnivore_HasMaxEnergy()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.MaximumEnergyPerUnitRadius >= 0);
+    }
+
+    [Fact]
+    public void GetSpeciesFromAssembly_SimpleHerbivore_ReturnsAnimalSpecies()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleHerbivore.SimpleHerbivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.NotNull(species);
+        Assert.IsType<AnimalSpecies>(species);
+    }
+
+    [Fact]
+    public void GetSpeciesFromAssembly_SimpleHerbivore_HasName()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleHerbivore.SimpleHerbivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.False(string.IsNullOrEmpty(species.Name));
+    }
+
+    // --- AnimalSpecies-specific attributes ---
+
+    [Fact]
+    public void AnimalSpecies_SimpleCarnivore_IsCarnivore()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = (AnimalSpecies)Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.IsCarnivore);
+    }
+
+    [Fact]
+    public void AnimalSpecies_SimpleHerbivore_IsNotCarnivore()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleHerbivore.SimpleHerbivore).Assembly;
+        var species = (AnimalSpecies)Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.False(species.IsCarnivore);
+    }
+
+    [Fact]
+    public void AnimalSpecies_HasMaximumSpeed()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = (AnimalSpecies)Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.MaximumSpeed > 0);
+    }
+
+    [Fact]
+    public void AnimalSpecies_HasEyesightRadius()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = (AnimalSpecies)Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.EyesightRadius > 0);
+    }
+
+    // --- Species properties ---
+
+    [Fact]
+    public void Species_InitialRadius_IsLessThanMatureRadius()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.InitialRadius < species.MatureRadius);
+    }
+
+    [Fact]
+    public void Species_LifeSpan_IsPositive()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.LifeSpan > 0);
+    }
+
+    [Fact]
+    public void Species_ReproductionWait_IsPositive()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.ReproductionWait > 0);
+    }
+
+    [Fact]
+    public void Species_GrowthWait_IsPositive()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.GrowthWait > 0);
+    }
+
+    [Fact]
+    public void Species_AssemblyFullName_IsNotEmpty()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.False(string.IsNullOrEmpty(species.AssemblyFullName));
+    }
+
+    [Fact]
+    public void Species_IsSameSpecies_MatchesSelf()
+    {
+        var assembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var species = Species.GetSpeciesFromAssembly(assembly);
+
+        Assert.True(species.IsSameSpecies(species));
+    }
+
+    [Fact]
+    public void Species_IsSameSpecies_DifferentSpecies_ReturnsFalse()
+    {
+        var carnivoreAssembly = typeof(Terrarium.Samples.SimpleCarnivore.SimpleCarnivore).Assembly;
+        var herbivoreAssembly = typeof(Terrarium.Samples.SimpleHerbivore.SimpleHerbivore).Assembly;
+        var carnivore = Species.GetSpeciesFromAssembly(carnivoreAssembly);
+        var herbivore = Species.GetSpeciesFromAssembly(herbivoreAssembly);
+
+        Assert.False(carnivore.IsSameSpecies(herbivore));
+    }
+
+    // --- GetAssemblyShortName ---
+
+    [Fact]
+    public void GetAssemblyShortName_ExtractsNameBeforeComma()
+    {
+        var result = typeof(Species)
+            .GetMethod("GetAssemblyShortName", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { "MyAssembly, Version=1.0.0.0, Culture=neutral" });
+
+        Assert.Equal("MyAssembly", result);
+    }
+
+    [Fact]
+    public void GetAssemblyShortName_ReturnsFullString_WhenNoComma()
+    {
+        var result = typeof(Species)
+            .GetMethod("GetAssemblyShortName", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { "SimpleAssemblyName" });
+
+        Assert.Equal("SimpleAssemblyName", result);
+    }
+}

--- a/src/Terrarium.Game.Tests/TickActionsTests.cs
+++ b/src/Terrarium.Game.Tests/TickActionsTests.cs
@@ -1,0 +1,159 @@
+using System.Drawing;
+using System.Reflection;
+using OrganismBase;
+using Xunit;
+
+namespace Terrarium.Game.Tests;
+
+/// <summary>
+/// Tests for TickActions: action aggregation for move, attack, eat, reproduce, defend.
+/// </summary>
+public class TickActionsTests
+{
+    private static readonly IAnimalSpecies AnimalSpecies = new MockAnimalSpecies();
+    private static readonly IPlantSpecies PlantSpecies = new MockPlantSpecies();
+
+    private static T CreateAction<T>(params object?[] args)
+    {
+        var ctor = typeof(T).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        Assert.NotEmpty(ctor);
+        return (T)ctor[0].Invoke(args)!;
+    }
+
+    // --- Empty state ---
+
+    [Fact]
+    public void TickActions_StartsEmpty()
+    {
+        var actions = new TickActions();
+
+        Assert.Empty(actions.MoveToActions);
+        Assert.Empty(actions.AttackActions);
+        Assert.Empty(actions.EatActions);
+        Assert.Empty(actions.ReproduceActions);
+        Assert.Empty(actions.DefendActions);
+    }
+
+    // --- ReadOnly dictionaries ---
+
+    [Fact]
+    public void MoveToActions_IsReadOnly()
+    {
+        var actions = new TickActions();
+        var dict = actions.MoveToActions;
+        Assert.IsAssignableFrom<IReadOnlyDictionary<string, MoveToAction>>(dict);
+    }
+
+    [Fact]
+    public void AttackActions_IsReadOnly()
+    {
+        var actions = new TickActions();
+        Assert.IsAssignableFrom<IReadOnlyDictionary<string, AttackAction>>(actions.AttackActions);
+    }
+
+    [Fact]
+    public void EatActions_IsReadOnly()
+    {
+        var actions = new TickActions();
+        Assert.IsAssignableFrom<IReadOnlyDictionary<string, EatAction>>(actions.EatActions);
+    }
+
+    [Fact]
+    public void ReproduceActions_IsReadOnly()
+    {
+        var actions = new TickActions();
+        Assert.IsAssignableFrom<IReadOnlyDictionary<string, ReproduceAction>>(actions.ReproduceActions);
+    }
+
+    [Fact]
+    public void DefendActions_IsReadOnly()
+    {
+        var actions = new TickActions();
+        Assert.IsAssignableFrom<IReadOnlyDictionary<string, DefendAction>>(actions.DefendActions);
+    }
+
+    // --- Action types have expected properties ---
+
+    [Fact]
+    public void MoveToAction_HasExpectedProperties()
+    {
+        var vector = new MovementVector(new Point(100, 200), 5);
+        var action = CreateAction<MoveToAction>("org-1", 1, vector);
+
+        Assert.Equal("org-1", action.OrganismID);
+        Assert.Equal(1, action.ActionID);
+        Assert.Equal(vector.Destination, action.MovementVector.Destination);
+        Assert.Equal(vector.Speed, action.MovementVector.Speed);
+    }
+
+    [Fact]
+    public void AttackAction_HasTargetAnimal()
+    {
+        var target = new AnimalState("target-1", AnimalSpecies, 0, EnergyState.Full, 10);
+        var action = CreateAction<AttackAction>("attacker-1", 2, target);
+
+        Assert.Same(target, action.TargetAnimal);
+    }
+
+    [Fact]
+    public void EatAction_HasTargetOrganism()
+    {
+        var target = new PlantState("food-1", PlantSpecies, 0, EnergyState.Full, 10);
+        var action = CreateAction<EatAction>("eater-1", 3, (OrganismState)target);
+
+        Assert.Same(target, action.TargetOrganism);
+    }
+
+    [Fact]
+    public void DefendAction_HasTargetAnimal()
+    {
+        var target = new AnimalState("att-1", AnimalSpecies, 0, EnergyState.Full, 10);
+        var action = CreateAction<DefendAction>("def-1", 7, target);
+
+        Assert.Same(target, action.TargetAnimal);
+    }
+
+    [Fact]
+    public void ReproduceAction_WithDna_ReturnsClone()
+    {
+        var dna = new byte[] { 1, 2, 3 };
+        var action = CreateAction<ReproduceAction>("p-1", 4, dna);
+
+        Assert.NotNull(action.Dna);
+        Assert.Equal(dna, action.Dna);
+        Assert.NotSame(dna, action.Dna);
+    }
+
+    // --- Mock species ---
+
+    private class MockAnimalSpecies : IAnimalSpecies
+    {
+        public int MatureRadius { get; set; } = 12;
+        public int ReproductionWait { get; set; } = 8;
+        public int LifeSpan { get; set; } = 1000;
+        public int GrowthWait { get; set; } = 5;
+        public int MaximumEnergyPerUnitRadius { get; set; } = 50;
+        public string Skin { get; set; } = "TestSkin";
+        public AnimalSkinFamily SkinFamily { get; set; } = AnimalSkinFamily.Ant;
+        public bool IsCarnivore { get; set; } = true;
+        public int EatingSpeedPerUnitRadius { get; set; } = 10;
+        public int MaximumAttackDamagePerUnitRadius { get; set; } = 60;
+        public int MaximumDefendDamagePerUnitRadius { get; set; } = 55;
+        public int MaximumSpeed { get; set; } = 50;
+        public int InvisibleOdds { get; set; } = 10;
+        public int EyesightRadius { get; set; } = 8;
+        public bool IsSameSpecies(ISpecies species) => species is MockAnimalSpecies;
+    }
+
+    private class MockPlantSpecies : IPlantSpecies
+    {
+        public int MatureRadius { get; set; } = 12;
+        public int ReproductionWait { get; set; } = 25;
+        public int LifeSpan { get; set; } = 2000;
+        public int GrowthWait { get; set; } = 5;
+        public int MaximumEnergyPerUnitRadius { get; set; } = 50;
+        public string Skin { get; set; } = "TestPlantSkin";
+        public PlantSkinFamily SkinFamily { get; set; } = PlantSkinFamily.Plant;
+        public bool IsSameSpecies(ISpecies species) => species is MockPlantSpecies;
+    }
+}

--- a/src/Terrarium.Game.Tests/WorldStateTests.cs
+++ b/src/Terrarium.Game.Tests/WorldStateTests.cs
@@ -1,0 +1,323 @@
+using System.Drawing;
+using OrganismBase;
+using Xunit;
+
+namespace Terrarium.Game.Tests;
+
+/// <summary>
+/// Tests for WorldState: grid creation, organism placement,
+/// cell queries, immutability, and index operations.
+/// </summary>
+public class WorldStateTests
+{
+    private static readonly IAnimalSpecies AnimalSpecies = new MockAnimalSpecies();
+    private static readonly IPlantSpecies PlantSpecies = new MockPlantSpecies();
+
+    private static AnimalState CreateAnimalAt(string id, int x, int y, int radius = 2)
+    {
+        var state = new AnimalState(id, AnimalSpecies, 0, EnergyState.Full, radius);
+        state.Position = new Point(
+            x << EngineSettings.GridWidthPowerOfTwo,
+            y << EngineSettings.GridHeightPowerOfTwo);
+        return state;
+    }
+
+    private static PlantState CreatePlantAt(string id, int x, int y, int radius = 2)
+    {
+        var state = new PlantState(id, PlantSpecies, 0, EnergyState.Full, radius);
+        state.Position = new Point(
+            x << EngineSettings.GridWidthPowerOfTwo,
+            y << EngineSettings.GridHeightPowerOfTwo);
+        return state;
+    }
+
+    // --- Grid creation ---
+
+    [Fact]
+    public void WorldState_CanBeCreated_WithDimensions()
+    {
+        var ws = new WorldState(100, 100);
+        Assert.NotNull(ws);
+        Assert.False(ws.IsImmutable);
+        Assert.False(ws.IndexBuilt);
+    }
+
+    [Fact]
+    public void WorldState_StartsEmpty()
+    {
+        var ws = new WorldState(50, 50);
+        Assert.Empty(ws.Organisms);
+        Assert.Empty(ws.OrganismIDs);
+    }
+
+    // --- Organism placement ---
+
+    [Fact]
+    public void AddOrganism_IncreasesCount()
+    {
+        var ws = new WorldState(100, 100);
+        var animal = CreateAnimalAt("a1", 10, 10);
+        ws.AddOrganism(animal);
+
+        Assert.Single(ws.Organisms);
+        Assert.Contains("a1", ws.OrganismIDs);
+    }
+
+    [Fact]
+    public void AddOrganism_MultiplePlacement()
+    {
+        var ws = new WorldState(100, 100);
+        ws.AddOrganism(CreateAnimalAt("a1", 10, 10));
+        ws.AddOrganism(CreatePlantAt("p1", 20, 20));
+
+        Assert.Equal(2, ws.Organisms.Count);
+    }
+
+    [Fact]
+    public void AddOrganism_DuplicateId_Throws()
+    {
+        var ws = new WorldState(100, 100);
+        ws.AddOrganism(CreateAnimalAt("a1", 10, 10));
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ws.AddOrganism(CreateAnimalAt("a1", 20, 20)));
+    }
+
+    // --- Cell queries ---
+
+    [Fact]
+    public void GetOrganismState_ReturnsPlacedOrganism()
+    {
+        var ws = new WorldState(100, 100);
+        var animal = CreateAnimalAt("a1", 10, 10);
+        ws.AddOrganism(animal);
+
+        var retrieved = ws.GetOrganismState("a1");
+        Assert.NotNull(retrieved);
+        Assert.Equal("a1", retrieved!.ID);
+    }
+
+    [Fact]
+    public void GetOrganismState_ReturnsNull_ForMissing()
+    {
+        var ws = new WorldState(100, 100);
+        Assert.Null(ws.GetOrganismState("nonexistent"));
+    }
+
+    [Fact]
+    public void IsGridCellOccupied_ReturnsTrue_ForOccupied()
+    {
+        // AddOrganism fills cells but doesn't set IndexBuilt.
+        // Use DuplicateMutable + BuildIndex to set up a properly indexed state.
+        var ws = new WorldState(100, 100);
+        var animal = CreateAnimalAt("a1", 10, 10);
+        ws.AddOrganism(animal);
+        ws.MakeImmutable();
+
+        var dup = ws.DuplicateMutable();
+        dup.BuildIndex();
+
+        Assert.True(dup.IsGridCellOccupied(10, 10));
+    }
+
+    [Fact]
+    public void IsGridCellOccupied_ReturnsFalse_ForEmpty()
+    {
+        var ws = new WorldState(100, 100);
+        ws.BuildIndex();
+
+        Assert.False(ws.IsGridCellOccupied(10, 10));
+    }
+
+    // --- Remove ---
+
+    [Fact]
+    public void RemoveOrganism_RemovesFromState()
+    {
+        var ws = new WorldState(100, 100);
+        ws.AddOrganism(CreateAnimalAt("a1", 10, 10));
+        ws.RemoveOrganism("a1");
+
+        Assert.Empty(ws.Organisms);
+        Assert.Null(ws.GetOrganismState("a1"));
+    }
+
+    // --- Immutability ---
+
+    [Fact]
+    public void MakeImmutable_SetsFlag()
+    {
+        var ws = new WorldState(100, 100);
+        ws.MakeImmutable();
+        Assert.True(ws.IsImmutable);
+    }
+
+    [Fact]
+    public void MakeImmutable_PreventsAddOrganism()
+    {
+        var ws = new WorldState(100, 100);
+        ws.MakeImmutable();
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ws.AddOrganism(CreateAnimalAt("a1", 10, 10)));
+    }
+
+    [Fact]
+    public void MakeImmutable_PreventsRemoveOrganism()
+    {
+        var ws = new WorldState(100, 100);
+        ws.AddOrganism(CreateAnimalAt("a1", 10, 10));
+        ws.MakeImmutable();
+
+        Assert.Throws<InvalidOperationException>(() => ws.RemoveOrganism("a1"));
+    }
+
+    [Fact]
+    public void MakeImmutable_PreventsTickNumberChange()
+    {
+        var ws = new WorldState(100, 100);
+        ws.MakeImmutable();
+
+        Assert.Throws<InvalidOperationException>(() => ws.TickNumber = 5);
+    }
+
+    [Fact]
+    public void MakeImmutable_PreventsStateGuidChange()
+    {
+        var ws = new WorldState(100, 100);
+        ws.MakeImmutable();
+
+        Assert.Throws<InvalidOperationException>(() => ws.StateGuid = Guid.NewGuid());
+    }
+
+    // --- DuplicateMutable ---
+
+    [Fact]
+    public void DuplicateMutable_CreatesModifiableCopy()
+    {
+        var ws = new WorldState(100, 100);
+        ws.AddOrganism(CreateAnimalAt("a1", 10, 10));
+        ws.TickNumber = 42;
+        ws.MakeImmutable();
+
+        var dup = ws.DuplicateMutable();
+        Assert.False(dup.IsImmutable);
+        Assert.Equal(42, dup.TickNumber);
+        Assert.NotNull(dup.GetOrganismState("a1"));
+    }
+
+    // --- TickNumber and StateGuid ---
+
+    [Fact]
+    public void TickNumber_CanBeSetAndRead()
+    {
+        var ws = new WorldState(100, 100);
+        ws.TickNumber = 99;
+        Assert.Equal(99, ws.TickNumber);
+    }
+
+    [Fact]
+    public void StateGuid_CanBeSetAndRead()
+    {
+        var ws = new WorldState(100, 100);
+        var guid = Guid.NewGuid();
+        ws.StateGuid = guid;
+        Assert.Equal(guid, ws.StateGuid);
+    }
+
+    // --- ZOrderedOrganisms ---
+
+    [Fact]
+    public void ZOrderedOrganisms_ReturnsSortedList()
+    {
+        var ws = new WorldState(100, 100);
+        ws.AddOrganism(CreateAnimalAt("a1", 10, 10));
+        ws.AddOrganism(CreatePlantAt("p1", 20, 20));
+
+        var ordered = ws.ZOrderedOrganisms;
+        Assert.Equal(2, ordered.Count);
+    }
+
+    // --- BuildIndex ---
+
+    [Fact]
+    public void BuildIndex_SetsIndexBuiltFlag()
+    {
+        var ws = new WorldState(100, 100);
+        ws.BuildIndex();
+        Assert.True(ws.IndexBuilt);
+    }
+
+    [Fact]
+    public void ClearIndex_ResetsFlag()
+    {
+        var ws = new WorldState(100, 100);
+        ws.BuildIndex();
+        ws.ClearIndex();
+        Assert.False(ws.IndexBuilt);
+    }
+
+    // --- FindOrganismsInCells ---
+
+    [Fact]
+    public void FindOrganismsInCells_FindsPlacedOrganism()
+    {
+        var ws = new WorldState(100, 100);
+        ws.AddOrganism(CreateAnimalAt("a1", 10, 10));
+        ws.MakeImmutable();
+
+        var dup = ws.DuplicateMutable();
+        dup.BuildIndex();
+
+        var found = dup.FindOrganismsInCells(8, 12, 8, 12);
+        Assert.Single(found);
+        Assert.Equal("a1", found[0].ID);
+    }
+
+    [Fact]
+    public void FindOrganismsInCells_ReturnsEmpty_WhenNoneInRange()
+    {
+        var ws = new WorldState(100, 100);
+        ws.AddOrganism(CreateAnimalAt("a1", 10, 10));
+        ws.MakeImmutable();
+
+        var dup = ws.DuplicateMutable();
+        dup.BuildIndex();
+
+        var found = dup.FindOrganismsInCells(50, 60, 50, 60);
+        Assert.Empty(found);
+    }
+
+    // --- Mock species ---
+
+    private class MockAnimalSpecies : IAnimalSpecies
+    {
+        public int MatureRadius { get; set; } = 12;
+        public int ReproductionWait { get; set; } = 8;
+        public int LifeSpan { get; set; } = 1000;
+        public int GrowthWait { get; set; } = 5;
+        public int MaximumEnergyPerUnitRadius { get; set; } = 50;
+        public string Skin { get; set; } = "TestSkin";
+        public AnimalSkinFamily SkinFamily { get; set; } = AnimalSkinFamily.Ant;
+        public bool IsCarnivore { get; set; } = true;
+        public int EatingSpeedPerUnitRadius { get; set; } = 10;
+        public int MaximumAttackDamagePerUnitRadius { get; set; } = 60;
+        public int MaximumDefendDamagePerUnitRadius { get; set; } = 55;
+        public int MaximumSpeed { get; set; } = 50;
+        public int InvisibleOdds { get; set; } = 10;
+        public int EyesightRadius { get; set; } = 8;
+        public bool IsSameSpecies(ISpecies species) => species is MockAnimalSpecies;
+    }
+
+    private class MockPlantSpecies : IPlantSpecies
+    {
+        public int MatureRadius { get; set; } = 12;
+        public int ReproductionWait { get; set; } = 25;
+        public int LifeSpan { get; set; } = 2000;
+        public int GrowthWait { get; set; } = 5;
+        public int MaximumEnergyPerUnitRadius { get; set; } = 50;
+        public string Skin { get; set; } = "TestPlantSkin";
+        public PlantSkinFamily SkinFamily { get; set; } = PlantSkinFamily.Plant;
+        public bool IsSameSpecies(ISpecies species) => species is MockPlantSpecies;
+    }
+}

--- a/src/Terrarium.Server.Tests/ChartsEndpointTests.cs
+++ b/src/Terrarium.Server.Tests/ChartsEndpointTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Terrarium.Server.Tests;
+
+/// <summary>
+/// Integration tests for the Charts endpoints (/api/charts/*).
+/// Endpoints gracefully return empty arrays when the DB is unavailable.
+/// </summary>
+public class ChartsEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public ChartsEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task PopulationHistory_WithSpecies_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/charts/population-history?species=TestSpecies");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task PopulationHistory_WithDateRange_ReturnsOk()
+    {
+        var begin = DateTime.UtcNow.AddDays(-7).ToString("o");
+        var end = DateTime.UtcNow.ToString("o");
+        var response = await _client.GetAsync(
+            $"/api/charts/population-history?species=TestSpecies&beginDate={begin}&endDate={end}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task SpeciesDistribution_ReturnsOk_WithArray()
+    {
+        var response = await _client.GetAsync("/api/charts/species-distribution");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task TopCreatures_WithVersion_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/charts/top-creatures?version=1.0.0.0");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task TopCreatures_WithTypeAndCount_ReturnsOk()
+    {
+        var response = await _client.GetAsync(
+            "/api/charts/top-creatures?version=1.0.0.0&type=Plant&count=5");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TopCreatures_DefaultsTypeToAnimal()
+    {
+        var response = await _client.GetAsync("/api/charts/top-creatures?version=1.0.0.0");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/src/Terrarium.Server.Tests/PeerDiscoveryEndpointTests.cs
+++ b/src/Terrarium.Server.Tests/PeerDiscoveryEndpointTests.cs
@@ -1,0 +1,145 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Terrarium.Server.Tests;
+
+/// <summary>
+/// Integration tests for the Peer Discovery endpoints (/api/discovery/*).
+/// Tests peer registration, listing, validation, user registration, and version check.
+/// </summary>
+public class PeerDiscoveryEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public PeerDiscoveryEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Register_WithEmptyVersion_ReturnsGlobalFailure()
+    {
+        var request = new RegisterPeerRequest
+        {
+            Version = "",
+            Channel = "test",
+            Guid = Guid.NewGuid()
+        };
+        var response = await _client.PostAsJsonAsync("/api/discovery/register", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<RegisterPeerResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(RegisterPeerResult.GlobalFailure, result!.Result);
+    }
+
+    [Fact]
+    public async Task Register_WithEmptyChannel_ReturnsGlobalFailure()
+    {
+        var request = new RegisterPeerRequest
+        {
+            Version = "1.0.0.0",
+            Channel = "",
+            Guid = Guid.NewGuid()
+        };
+        var response = await _client.PostAsJsonAsync("/api/discovery/register", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<RegisterPeerResponse>();
+        Assert.Equal(RegisterPeerResult.GlobalFailure, result!.Result);
+    }
+
+    [Fact]
+    public async Task Register_WithValidPayload_ReturnsFailure_WhenNoDb()
+    {
+        var request = new RegisterPeerRequest
+        {
+            Version = "1.0.0.0",
+            Channel = "test-channel",
+            Guid = Guid.NewGuid()
+        };
+        var response = await _client.PostAsJsonAsync("/api/discovery/register", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<RegisterPeerResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(RegisterPeerResult.Failure, result!.Result);
+    }
+
+    [Fact]
+    public async Task Peers_WithEmptyVersion_ReturnsZeroCount()
+    {
+        var response = await _client.GetAsync("/api/discovery/peers?version=&channel=test");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<PeerCountResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(0, result!.Count);
+    }
+
+    [Fact]
+    public async Task Peers_WithEmptyChannel_ReturnsZeroCount()
+    {
+        var response = await _client.GetAsync("/api/discovery/peers?version=1.0.0.0&channel=");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<PeerCountResponse>();
+        Assert.Equal(0, result!.Count);
+    }
+
+    [Fact]
+    public async Task Peers_WithValidParams_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/discovery/peers?version=1.0.0.0&channel=test");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<PeerCountResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(0, result!.Count);
+    }
+
+    [Fact]
+    public async Task Validate_ReturnsOk_WithIpAddress()
+    {
+        var response = await _client.GetAsync("/api/discovery/validate");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.True(doc.RootElement.TryGetProperty("ipAddress", out _));
+    }
+
+    [Fact]
+    public async Task RegisterUser_ReturnsOk()
+    {
+        var request = new RegisterUserRequest { Email = "test@example.com" };
+        var response = await _client.PostAsJsonAsync("/api/discovery/register-user", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.True(doc.RootElement.TryGetProperty("success", out _));
+    }
+
+    [Fact]
+    public async Task VersionCheck_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/discovery/version-check?version=1.0.0.0");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task VersionCheck_ReturnsDisabledTrue_WhenNoDb()
+    {
+        var response = await _client.GetAsync("/api/discovery/version-check?version=1.0.0.0");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<VersionCheckResponse>();
+        Assert.NotNull(result);
+        Assert.True(result!.Disabled);
+    }
+}

--- a/src/Terrarium.Server.Tests/ReportingEndpointTests.cs
+++ b/src/Terrarium.Server.Tests/ReportingEndpointTests.cs
@@ -1,0 +1,122 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Terrarium.Server.Tests;
+
+/// <summary>
+/// Integration tests for the Reporting endpoints (/api/reporting/*).
+/// Endpoints gracefully return defaults when the DB is unavailable.
+/// </summary>
+public class ReportingEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public ReportingEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Population_WithEmptyGuid_ReturnsSuccess()
+    {
+        var request = new ReportPopulationRequest
+        {
+            Guid = Guid.Empty,
+            CurrentTick = 0,
+            History = []
+        };
+        var response = await _client.PostAsJsonAsync("/api/reporting/population", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ReportPopulationResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(ReportingReturnCode.Success, result!.ReturnCode);
+    }
+
+    [Fact]
+    public async Task Population_WithEmptyHistory_ReturnsSuccess()
+    {
+        var request = new ReportPopulationRequest
+        {
+            Guid = Guid.NewGuid(),
+            CurrentTick = 1,
+            History = []
+        };
+        var response = await _client.PostAsJsonAsync("/api/reporting/population", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ReportPopulationResponse>();
+        Assert.Equal(ReportingReturnCode.Success, result!.ReturnCode);
+    }
+
+    [Fact]
+    public async Task Population_WithHistory_ReturnsOk_WhenNoDb()
+    {
+        var request = new ReportPopulationRequest
+        {
+            Guid = Guid.NewGuid(),
+            CurrentTick = 10,
+            History =
+            [
+                new PopulationHistoryRow
+                {
+                    Guid = Guid.NewGuid(),
+                    TickNumber = 10,
+                    SpeciesName = "TestSpecies",
+                    ClientTime = DateTime.UtcNow,
+                    CorrectTime = 1,
+                    Population = 50
+                }
+            ]
+        };
+        var response = await _client.PostAsJsonAsync("/api/reporting/population", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ReportPopulationResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(ReportingReturnCode.Success, result!.ReturnCode);
+    }
+
+    [Fact]
+    public async Task StatsSpeciesList_ReturnsOk_WithArray()
+    {
+        var response = await _client.GetAsync("/api/reporting/stats/species-list");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task StatsLatest_ReturnsOk_WithArray()
+    {
+        var response = await _client.GetAsync("/api/reporting/stats/latest?species=TestSpecies");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task StatsTopAnimals_ReturnsOk_WithArray()
+    {
+        var response = await _client.GetAsync("/api/reporting/stats/top-animals?version=1.0.0.0&type=Animal");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task StatsTopAnimals_WithCount_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/reporting/stats/top-animals?version=1.0.0.0&type=Animal&count=5");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/src/Terrarium.Server.Tests/SpeciesEndpointTests.cs
+++ b/src/Terrarium.Server.Tests/SpeciesEndpointTests.cs
@@ -1,0 +1,211 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Terrarium.Server.Tests;
+
+/// <summary>
+/// Integration tests for the Species endpoints (/api/species/*).
+/// Endpoints that require a SQL connection gracefully return defaults when the DB is unavailable.
+/// </summary>
+public class SpeciesEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public SpeciesEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Register_WithEmptyBody_ReturnsVersionIncompatible()
+    {
+        var request = new RegisterSpeciesRequest();
+        var response = await _client.PostAsJsonAsync("/api/species/register", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<RegisterSpeciesResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(SpeciesServiceStatus.VersionIncompatible, result!.Status);
+    }
+
+    [Fact]
+    public async Task Register_WithMissingName_ReturnsVersionIncompatible()
+    {
+        var request = new RegisterSpeciesRequest
+        {
+            Version = "1.0.0.0",
+            Type = "Animal",
+            Author = "Test",
+            Email = "test@test.com",
+            AssemblyFullName = "TestAssembly",
+            AssemblyCode = new byte[] { 1, 2, 3 }
+        };
+        var response = await _client.PostAsJsonAsync("/api/species/register", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<RegisterSpeciesResponse>();
+        Assert.Equal(SpeciesServiceStatus.VersionIncompatible, result!.Status);
+    }
+
+    [Fact]
+    public async Task Register_WithMissingAssemblyCode_ReturnsVersionIncompatible()
+    {
+        var request = new RegisterSpeciesRequest
+        {
+            Name = "TestSpecies",
+            Version = "1.0.0.0",
+            Type = "Animal",
+            Author = "Test",
+            Email = "test@test.com",
+            AssemblyFullName = "TestAssembly"
+        };
+        var response = await _client.PostAsJsonAsync("/api/species/register", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<RegisterSpeciesResponse>();
+        Assert.Equal(SpeciesServiceStatus.VersionIncompatible, result!.Status);
+    }
+
+    [Fact]
+    public async Task Register_WithFullPayload_ReturnsServerDown_WhenNoDb()
+    {
+        var request = new RegisterSpeciesRequest
+        {
+            Name = "TestSpecies",
+            Version = "1.0.0.0",
+            Type = "Animal",
+            Author = "TestAuthor",
+            Email = "test@test.com",
+            AssemblyFullName = "Test.Assembly, Version=1.0.0.0",
+            AssemblyCode = new byte[] { 0x4D, 0x5A, 0x90, 0x00 }
+        };
+        var response = await _client.PostAsJsonAsync("/api/species/register", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<RegisterSpeciesResponse>();
+        Assert.NotNull(result);
+        Assert.Equal(SpeciesServiceStatus.ServerDown, result!.Status);
+    }
+
+    [Fact]
+    public async Task List_WithoutVersion_ReturnsEmptyArray()
+    {
+        var response = await _client.GetAsync("/api/species/list?version=");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.Equal(0, doc.RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task List_WithVersion_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/species/list?version=1.0.0.0");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task List_WithFilterAll_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/species/list?version=1.0.0.0&filter=All");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Extinct_WithoutVersion_ReturnsEmptyArray()
+    {
+        var response = await _client.GetAsync("/api/species/extinct?version=");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.Equal(0, doc.RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Extinct_WithVersion_ReturnsOk()
+    {
+        var response = await _client.GetAsync("/api/species/extinct?version=1.0.0.0");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Blacklisted_ReturnsOk_WithArray()
+    {
+        var response = await _client.GetAsync("/api/species/blacklisted");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task Reintroduce_WithEmptyRequest_ReturnsFalse()
+    {
+        var request = new ReintroduceSpeciesRequest();
+        var response = await _client.PostAsJsonAsync("/api/species/reintroduce", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ReintroduceSpeciesResponse>();
+        Assert.NotNull(result);
+        Assert.False(result!.Success);
+    }
+
+    [Fact]
+    public async Task Reintroduce_WithMissingName_ReturnsFalse()
+    {
+        var request = new ReintroduceSpeciesRequest
+        {
+            Version = "1.0.0.0",
+            PeerGuid = Guid.NewGuid()
+        };
+        var response = await _client.PostAsJsonAsync("/api/species/reintroduce", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ReintroduceSpeciesResponse>();
+        Assert.False(result!.Success);
+    }
+
+    [Fact]
+    public async Task Reintroduce_WithMissingGuid_ReturnsFalse()
+    {
+        var request = new ReintroduceSpeciesRequest
+        {
+            Name = "TestSpecies",
+            Version = "1.0.0.0"
+        };
+        var response = await _client.PostAsJsonAsync("/api/species/reintroduce", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ReintroduceSpeciesResponse>();
+        Assert.False(result!.Success);
+    }
+
+    [Fact]
+    public async Task Reintroduce_WithValidPayload_ReturnsFalse_WhenNoDb()
+    {
+        var request = new ReintroduceSpeciesRequest
+        {
+            Name = "TestSpecies",
+            Version = "1.0.0.0",
+            PeerGuid = Guid.NewGuid()
+        };
+        var response = await _client.PostAsJsonAsync("/api/species/reintroduce", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ReintroduceSpeciesResponse>();
+        Assert.NotNull(result);
+        Assert.False(result!.Success);
+    }
+}

--- a/src/Terrarium.Server.Tests/UsageEndpointTests.cs
+++ b/src/Terrarium.Server.Tests/UsageEndpointTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Terrarium.Server.Tests;
+
+/// <summary>
+/// Integration tests for the Usage endpoints (/api/usage/*).
+/// Tests heartbeat validation, daily stats, and version check.
+/// </summary>
+public class UsageEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public UsageEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Heartbeat_WithEmptyGuid_ReturnsFalse()
+    {
+        var request = new HeartbeatRequest { Guid = Guid.Empty, CurrentTick = 1 };
+        var response = await _client.PostAsJsonAsync("/api/usage/heartbeat", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<HeartbeatResponse>();
+        Assert.NotNull(result);
+        Assert.False(result!.Success);
+    }
+
+    [Fact]
+    public async Task Heartbeat_WithValidGuid_ReturnsOk_WhenNoDb()
+    {
+        var request = new HeartbeatRequest { Guid = Guid.NewGuid(), CurrentTick = 1 };
+        var response = await _client.PostAsJsonAsync("/api/usage/heartbeat", request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<HeartbeatResponse>();
+        Assert.NotNull(result);
+        Assert.False(result!.Success);
+    }
+
+    [Fact]
+    public async Task DailyStats_ReturnsOk_WithDefaultValues()
+    {
+        var response = await _client.GetAsync("/api/usage/daily-stats");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<DailyStatsResponse>();
+        Assert.NotNull(result);
+        Assert.True(result!.ActivePeers >= 0);
+        Assert.True(result.SpeciesCount >= 0);
+        Assert.True(result.TotalPopulation >= 0);
+    }
+
+    [Fact]
+    public async Task VersionCheck_ReturnsOk_WithSettings()
+    {
+        var response = await _client.GetAsync("/api/usage/version-check");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ServerVersionResponse>();
+        Assert.NotNull(result);
+        Assert.False(string.IsNullOrEmpty(result!.LatestVersion));
+        Assert.False(string.IsNullOrEmpty(result.MOTD));
+    }
+
+    [Fact]
+    public async Task VersionCheck_ReturnsDefaultVersion()
+    {
+        var response = await _client.GetAsync("/api/usage/version-check");
+        var result = await response.Content.ReadFromJsonAsync<ServerVersionResponse>();
+
+        Assert.Equal("1.0.0.0", result!.LatestVersion);
+    }
+
+    [Fact]
+    public async Task VersionCheck_ReturnsDefaultMotd()
+    {
+        var response = await _client.GetAsync("/api/usage/version-check");
+        var result = await response.Content.ReadFromJsonAsync<ServerVersionResponse>();
+
+        Assert.Equal("Have Fun!", result!.MOTD);
+    }
+}


### PR DESCRIPTION
## Sprint 5

Closes #40

- Comprehensive server endpoint integration tests (Species, Reporting, Charts, Usage, PeerDiscovery)
- Game engine unit tests for WorldState, TickActions, Species, GameEngine
- 117 new tests (43 server + 74 game), all passing
- Total test suite: 262 tests across 3 projects