### PR TITLE
GameScheduler, assembly cache, IL validator

### DIFF
--- a/src/Terrarium.Game/Hosting/AssemblyValidator.cs
+++ b/src/Terrarium.Game/Hosting/AssemblyValidator.cs
@@ -1,0 +1,264 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Microsoft.Extensions.Logging;
+
+namespace Terrarium.Game.Hosting;
+
+/// <summary>
+/// Result of assembly validation.
+/// </summary>
+public sealed class ValidationResult
+{
+    public bool IsValid { get; }
+    public IReadOnlyList<string> Reasons { get; }
+
+    private ValidationResult(bool isValid, IReadOnlyList<string> reasons)
+    {
+        IsValid = isValid;
+        Reasons = reasons;
+    }
+
+    public static ValidationResult Pass() => new(true, Array.Empty<string>());
+    public static ValidationResult Fail(IReadOnlyList<string> reasons) => new(false, reasons);
+}
+
+/// <summary>
+/// Managed IL validator that replaces the legacy C++ AsmCheck tool.
+/// Uses <see cref="System.Reflection.Metadata"/> to inspect assemblies without
+/// loading them, checking for forbidden P/Invoke declarations, forbidden
+/// namespace usage, and validating inheritance chains.
+/// </summary>
+public sealed class AssemblyValidator
+{
+    private readonly ILogger<AssemblyValidator> _logger;
+
+    /// <summary>
+    /// Namespaces that organism assemblies are forbidden from using.
+    /// </summary>
+    private static readonly string[] ForbiddenNamespaces =
+    [
+        "System.IO",
+        "System.Net",
+        "System.Diagnostics.Process",
+        "System.Runtime.InteropServices",
+        "System.Reflection.Emit",
+        "System.Threading",
+        "System.Security",
+        "Microsoft.Win32",
+    ];
+
+    /// <summary>
+    /// Fully qualified base type names that organisms must extend.
+    /// </summary>
+    private static readonly HashSet<string> AllowedBaseTypes = new(StringComparer.Ordinal)
+    {
+        "OrganismBase.Animal",
+        "OrganismBase.Plant",
+    };
+
+    public AssemblyValidator(ILogger<AssemblyValidator> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Validates an assembly at the given path without loading it into the runtime.
+    /// </summary>
+    /// <param name="assemblyPath">Path to the assembly DLL to validate.</param>
+    /// <returns>A <see cref="ValidationResult"/> describing whether the assembly is valid.</returns>
+    public ValidationResult Validate(string assemblyPath)
+    {
+        var errors = new List<string>();
+
+        if (!File.Exists(assemblyPath))
+        {
+            return ValidationResult.Fail([$"Assembly file not found: {assemblyPath}"]);
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(stream);
+
+            if (!peReader.HasMetadata)
+            {
+                return ValidationResult.Fail(["Assembly does not contain managed metadata."]);
+            }
+
+            var metadataReader = peReader.GetMetadataReader();
+
+            CheckForPInvoke(metadataReader, errors);
+            CheckForbiddenNamespaces(metadataReader, errors);
+            CheckInheritanceChain(metadataReader, errors);
+        }
+        catch (BadImageFormatException ex)
+        {
+            _logger.LogWarning(ex, "Assembly has invalid format: {Path}", assemblyPath);
+            return ValidationResult.Fail([$"Invalid assembly format: {ex.Message}"]);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error validating assembly: {Path}", assemblyPath);
+            return ValidationResult.Fail([$"Validation error: {ex.Message}"]);
+        }
+
+        if (errors.Count > 0)
+        {
+            _logger.LogWarning("Assembly validation failed for {Path} with {Count} error(s).",
+                assemblyPath, errors.Count);
+        }
+        else
+        {
+            _logger.LogDebug("Assembly validation passed for {Path}.", assemblyPath);
+        }
+
+        return errors.Count == 0
+            ? ValidationResult.Pass()
+            : ValidationResult.Fail(errors);
+    }
+
+    /// <summary>
+    /// Checks for any P/Invoke (DllImport) declarations which are forbidden in organism assemblies.
+    /// </summary>
+    private void CheckForPInvoke(MetadataReader reader, List<string> errors)
+    {
+        foreach (var methodDefHandle in reader.MethodDefinitions)
+        {
+            var methodDef = reader.GetMethodDefinition(methodDefHandle);
+
+            if ((methodDef.Attributes & MethodAttributes.PinvokeImpl) != 0)
+            {
+                var methodName = reader.GetString(methodDef.Name);
+                var declaringType = reader.GetTypeDefinition(methodDef.GetDeclaringType());
+                var typeName = reader.GetString(declaringType.Name);
+                var typeNamespace = reader.GetString(declaringType.Namespace);
+
+                errors.Add(
+                    $"Forbidden P/Invoke declaration: {typeNamespace}.{typeName}.{methodName}");
+            }
+
+            var implAttributes = methodDef.ImplAttributes;
+            if ((implAttributes & MethodImplAttributes.Unmanaged) != 0 ||
+                (implAttributes & MethodImplAttributes.Native) != 0)
+            {
+                var methodName = reader.GetString(methodDef.Name);
+                errors.Add($"Forbidden unmanaged/native method: {methodName}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Scans type references for usage of forbidden namespaces.
+    /// </summary>
+    private void CheckForbiddenNamespaces(MetadataReader reader, List<string> errors)
+    {
+        foreach (var typeRefHandle in reader.TypeReferences)
+        {
+            var typeRef = reader.GetTypeReference(typeRefHandle);
+            var ns = reader.GetString(typeRef.Namespace);
+            var name = reader.GetString(typeRef.Name);
+
+            foreach (var forbidden in ForbiddenNamespaces)
+            {
+                if (ns.Equals(forbidden, StringComparison.Ordinal) ||
+                    ns.StartsWith(forbidden + ".", StringComparison.Ordinal))
+                {
+                    errors.Add($"Forbidden namespace reference: {ns}.{name}");
+                    break;
+                }
+            }
+        }
+
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            var ns = reader.GetString(typeDef.Namespace);
+
+            foreach (var forbidden in ForbiddenNamespaces)
+            {
+                if (ns.Equals(forbidden, StringComparison.Ordinal) ||
+                    ns.StartsWith(forbidden + ".", StringComparison.Ordinal))
+                {
+                    var name = reader.GetString(typeDef.Name);
+                    errors.Add($"Type declared in forbidden namespace: {ns}.{name}");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Validates that at least one public type in the assembly extends Animal or Plant.
+    /// </summary>
+    private void CheckInheritanceChain(MetadataReader reader, List<string> errors)
+    {
+        var hasValidBase = false;
+
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+
+            if ((typeDef.Attributes & TypeAttributes.Public) == 0) continue;
+            if ((typeDef.Attributes & TypeAttributes.Abstract) != 0) continue;
+
+            if (HasAllowedBaseType(reader, typeDef))
+            {
+                hasValidBase = true;
+                break;
+            }
+        }
+
+        if (!hasValidBase)
+        {
+            errors.Add(
+                "No public non-abstract type found that extends OrganismBase.Animal or OrganismBase.Plant.");
+        }
+    }
+
+    /// <summary>
+    /// Walks the base type chain of a type definition to see if it ultimately
+    /// extends one of the allowed base types.
+    /// </summary>
+    private static bool HasAllowedBaseType(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var baseTypeHandle = typeDef.BaseType;
+
+        for (var depth = 0; depth < 20 && !baseTypeHandle.IsNil; depth++)
+        {
+            string? baseNamespace;
+            string? baseName;
+
+            switch (baseTypeHandle.Kind)
+            {
+                case HandleKind.TypeReference:
+                    var typeRef = reader.GetTypeReference((TypeReferenceHandle)baseTypeHandle);
+                    baseNamespace = reader.GetString(typeRef.Namespace);
+                    baseName = reader.GetString(typeRef.Name);
+
+                    if (AllowedBaseTypes.Contains($"{baseNamespace}.{baseName}"))
+                        return true;
+
+                    return false;
+
+                case HandleKind.TypeDefinition:
+                    var baseTypeDef = reader.GetTypeDefinition((TypeDefinitionHandle)baseTypeHandle);
+                    baseNamespace = reader.GetString(baseTypeDef.Namespace);
+                    baseName = reader.GetString(baseTypeDef.Name);
+
+                    if (AllowedBaseTypes.Contains($"{baseNamespace}.{baseName}"))
+                        return true;
+
+                    baseTypeHandle = baseTypeDef.BaseType;
+                    break;
+
+                default:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Terrarium.Game/Hosting/GameScheduler.cs
+++ b/src/Terrarium.Game/Hosting/GameScheduler.cs
@@ -1,0 +1,556 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using OrganismBase;
+using Terrarium.Configuration;
+
+namespace Terrarium.Game.Hosting;
+
+/// <summary>
+/// Manages creature execution within the game engine. Allocates time quanta
+/// per organism per tick, runs their think methods, and tracks timing/overage
+/// to penalize or blacklist creatures that exceed their budget.
+/// </summary>
+public sealed class GameScheduler : IDisposable
+{
+    // If an animal actually gets this much elapsed time in a single timeslice, we permanently blacklist them.
+    private const int DeadlockThresholdMs = 5000; // 5 seconds
+
+    // How often deadlock detection checks whether an animal has returned
+    private const int DeadlockCheckIntervalMs = 7500;
+
+    // How many retries before we restart without blacklisting
+    private const int DeadlockRetries = 3;
+
+    private const int ReportInterval = 150;
+
+    private readonly ILogger<GameScheduler> _logger;
+    private readonly TimeMonitor _monitor = new();
+    private readonly SemaphoreSlim _activationGate = new(0, 1);
+    private readonly SemaphoreSlim _completionGate = new(0, 1);
+
+    private readonly Dictionary<string, OrganismWrapper> _organismsById = new();
+    private readonly List<OrganismWrapper> _organismsList = new();
+
+    private GameEngine? _currentEngine;
+    private PrivateAssemblyCache? _pac;
+
+    private OrganismWrapper? _currentBug;
+    private CancellationTokenSource? _timeoutCts;
+    private Task? _activationTask;
+    private volatile bool _exitRequested;
+
+    private int _organismsActivated;
+    private int _orgEnumIndex;
+    private int _tickCount;
+    private long _totalActivations;
+    private long _lastReport;
+    private int _ticksToSuspendBlacklisting;
+    private bool _penalizeForTime = true;
+    private bool _disposed;
+
+    public GameScheduler(ILogger<GameScheduler> logger)
+    {
+        _logger = logger;
+        MaxAllowance = EngineSettings.OrganismSchedulingBlacklistOvertime;
+        TicksPerSec = 5;
+        Quantum = 5000;
+        MaxOverage = EngineSettings.OrganismSchedulingMaximumOvertime;
+
+        Debug.Assert(MaxOverage > Quantum);
+
+        _activationTask = Task.Run(ActivationLoop);
+    }
+
+    // --- Properties ---
+
+    /// <summary>Number of creatures run per tick.</summary>
+    public int OrganismsPerTick => (_organismsList.Count / TicksPerSec) + 1;
+
+    /// <summary>Ticks per second (buckets organisms are divided into).</summary>
+    public int TicksPerSec { get; set; }
+
+    /// <summary>Maximum microseconds allowed per organism turn.</summary>
+    public int Quantum { get; set; }
+
+    /// <summary>Maximum overtime before organism turn is skipped.</summary>
+    public long MaxOverage { get; set; }
+
+    /// <summary>Maximum overtime before organism is permanently removed (microseconds).</summary>
+    public long MaxAllowance { get; set; }
+
+    /// <summary>The current world state snapshot.</summary>
+    public WorldState? CurrentState { get; set; }
+
+    /// <summary>Whether to penalize organisms for exceeding time budgets.</summary>
+    public bool PenalizeForTime
+    {
+        get => DetectDeadlock && _penalizeForTime;
+        set => _penalizeForTime = value;
+    }
+
+    /// <summary>Suspend blacklisting entirely.</summary>
+    public bool SuspendBlacklisting { get; set; }
+
+    /// <summary>Whether deadlock detection is active.</summary>
+    public bool DetectDeadlock
+    {
+        get
+        {
+            if (Debugger.IsAttached) return false;
+            if (_ticksToSuspendBlacklisting > 0) return false;
+            return !SuspendBlacklisting;
+        }
+    }
+
+    /// <summary>All organisms currently in the scheduler.</summary>
+    public IReadOnlyList<Organism> Organisms
+    {
+        get
+        {
+            var list = new List<Organism>(_organismsList.Count);
+            foreach (var wrapper in _organismsList)
+            {
+                list.Add(wrapper.Organism);
+            }
+            return list;
+        }
+    }
+
+    /// <summary>The number of loaded organisms.</summary>
+    public int OrganismCount => _organismsList.Count;
+
+    /// <summary>
+    /// Sets the current game engine and wires up the assembly cache.
+    /// </summary>
+    public GameEngine? CurrentGameEngine
+    {
+        get => _currentEngine;
+        set
+        {
+            _currentEngine = value;
+            // TODO: Sprint 7 — wire up PAC from engine when available
+        }
+    }
+
+    /// <summary>
+    /// Sets the private assembly cache used for assembly resolution.
+    /// </summary>
+    public PrivateAssemblyCache? Pac
+    {
+        get => _pac;
+        set
+        {
+            _pac?.Close();
+            _pac = value;
+            // TODO: Sprint 7 — hook assembly resolve via AssemblyLoadContext
+        }
+    }
+
+    // --- Core scheduling ---
+
+    /// <summary>
+    /// Called by the game engine each tick to give a set of organisms time slices.
+    /// </summary>
+    public void Tick()
+    {
+        var activated = 0;
+
+        if (_ticksToSuspendBlacklisting > 0)
+        {
+            _logger.LogDebug("Suspending blacklisting for this tick.");
+        }
+
+        if (_organismsActivated < _organismsList.Count)
+        {
+            while (activated < OrganismsPerTick && _orgEnumIndex < _organismsList.Count)
+            {
+                var wrapper = _organismsList[_orgEnumIndex];
+                _orgEnumIndex++;
+                activated++;
+
+                RunOrganismWithDeadlockDetection(wrapper);
+            }
+        }
+
+        _organismsActivated += activated;
+        _tickCount++;
+
+        if (_organismsActivated >= _organismsList.Count && _tickCount >= TicksPerSec)
+        {
+            _orgEnumIndex = 0;
+            _organismsActivated = 0;
+            _tickCount = 0;
+            if (_ticksToSuspendBlacklisting > 0)
+            {
+                _ticksToSuspendBlacklisting--;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds an organism to the scheduler.
+    /// </summary>
+    public void Add(Organism org, string id)
+    {
+        Debug.Assert(_organismsActivated == 0);
+
+        if (_organismsById.ContainsKey(id))
+        {
+            throw new InvalidOperationException($"Organism '{id}' already exists in the scheduler.");
+        }
+
+        var wrapper = new OrganismWrapper(org, id);
+        _organismsById[id] = wrapper;
+        _organismsList.Add(wrapper);
+    }
+
+    /// <summary>
+    /// Retrieves an organism by ID.
+    /// </summary>
+    public Organism? GetOrganism(string id)
+    {
+        return _organismsById.TryGetValue(id, out var wrapper) ? wrapper.Organism : null;
+    }
+
+    /// <summary>
+    /// Removes an organism from the scheduler.
+    /// </summary>
+    public void Remove(string organismID)
+    {
+        if (_organismsById.Remove(organismID, out var wrapper))
+        {
+            _organismsList.Remove(wrapper);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new organism of the given species type and adds it.
+    /// </summary>
+    public void Create(Type species, string id)
+    {
+        var newOrganism = (Organism?)Activator.CreateInstance(species)
+            ?? throw new InvalidOperationException($"Failed to create instance of: {species}");
+
+        Add(newOrganism, id);
+    }
+
+    /// <summary>
+    /// Gathers all pending actions from organisms.
+    /// </summary>
+    public TickActions GatherTickActions()
+    {
+        var act = new TickActions();
+        act.GatherActionsFromOrganisms(Organisms);
+        return act;
+    }
+
+    /// <summary>
+    /// Temporarily suspends blacklisting for the next 2 ticks (e.g. power saving mode).
+    /// </summary>
+    public void TemporarilySuspendBlacklisting()
+    {
+        _ticksToSuspendBlacklisting = 2;
+    }
+
+    /// <summary>
+    /// Returns a timing report for the specified organism.
+    /// </summary>
+    public string GetOrganismTimingReport(string organismID)
+    {
+        if (!_organismsById.TryGetValue(organismID, out var w))
+        {
+            return "[organism doesn't exist]";
+        }
+
+        if (!PenalizeForTime)
+        {
+            return $"Inaccurate time due to debugging: {w.LastTime} microseconds";
+        }
+
+        return w.LastTime > Quantum
+            ? $"Warning: Time to execute last turn: {w.LastTime} microseconds is over maximum allowed time of {Quantum} microseconds. Animal may be penalized by skipping a turn."
+            : $"Time to execute last turn: {w.LastTime} microseconds. [less than maximum allowed time of {Quantum} microseconds.]";
+    }
+
+    // --- Deadlock detection ---
+
+    /// <summary>
+    /// Runs an organism with deadlock detection using CancellationToken-based timeouts
+    /// instead of Thread.Abort.
+    /// </summary>
+    private void RunOrganismWithDeadlockDetection(OrganismWrapper currentAnimal)
+    {
+        var sw = Stopwatch.StartNew();
+        var tries = 0;
+        var blacklist = false;
+        var shutdownWithoutBlacklist = false;
+
+        // Hand the activation loop an organism and kick off processing
+        _currentBug = currentAnimal;
+        _activationGate.Release();
+
+        while (true)
+        {
+            var executionDone = _completionGate.Wait(DeadlockCheckIntervalMs);
+
+            if (!executionDone)
+            {
+                _logger.LogWarning("Organism thread not stopped after {Interval} ms, checking elapsed time.",
+                    DeadlockCheckIntervalMs);
+
+                if (DetectDeadlock)
+                {
+                    if (PenalizeForTime)
+                    {
+                        var elapsedMs = sw.ElapsedMilliseconds;
+                        if (elapsedMs > DeadlockThresholdMs)
+                        {
+                            _logger.LogError("Thread overtime: {Seconds:F2} seconds, blacklist and exit.",
+                                elapsedMs / 1000.0);
+                            blacklist = true;
+                            break;
+                        }
+                    }
+
+                    tries++;
+                    if (tries >= DeadlockRetries)
+                    {
+                        _logger.LogWarning("Tried accessing organism thread {Tries} times, not blacklisted — restart.",
+                            tries);
+                        shutdownWithoutBlacklist = true;
+                        break;
+                    }
+                }
+                else
+                {
+                    _logger.LogDebug("Deadlock detection off.");
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        HandleRestartsAndBlacklist(currentAnimal, blacklist);
+        HandleRestartWithoutBlacklist(blacklist, shutdownWithoutBlacklist);
+    }
+
+    private static void HandleRestartWithoutBlacklist(bool blacklist, bool shutdownWithoutBlacklist)
+    {
+        if (shutdownWithoutBlacklist || blacklist)
+        {
+            throw new MaliciousOrganismException();
+        }
+    }
+
+    private void HandleRestartsAndBlacklist(OrganismWrapper currentAnimal, bool blacklist)
+    {
+        if (DetectDeadlock && blacklist)
+        {
+            var speciesName = currentAnimal.Organism.State?.Species is Species s
+                ? s.AssemblyFullName
+                : currentAnimal.ID;
+
+            _logger.LogError("Permanently blacklisting: {Species}", speciesName);
+
+            if (_pac != null)
+            {
+                _pac.LastRun = speciesName;
+            }
+
+            throw new MaliciousOrganismException();
+        }
+    }
+
+    // --- Activation loop (runs on background Task) ---
+
+    /// <summary>
+    /// Background loop that waits for organisms to be scheduled, then executes
+    /// their think method with timeout protection via CancellationToken.
+    /// </summary>
+    private void ActivationLoop()
+    {
+        while (!_exitRequested)
+        {
+            _activationGate.Wait();
+            if (_exitRequested) return;
+
+            var bug = _currentBug!;
+            var success = false;
+            long duration = 0;
+            var deathReason = PopulationChangeReason.NotDead;
+            var exceptionInfo = "";
+            var skippedTurn = false;
+
+            if (bug.Active)
+            {
+                var state = CurrentState?.GetOrganismState(bug.Organism.ID);
+                if (state == null || !state.IsAlive)
+                {
+                    bug.Active = false;
+                }
+                else
+                {
+                    using var cts = new CancellationTokenSource();
+                    _timeoutCts = cts;
+
+                    try
+                    {
+                        if (bug.Overage > MaxAllowance)
+                        {
+                            _logger.LogWarning("Organism blacklisted: overage {Overage} > max allowance {Max}.",
+                                bug.Overage, MaxAllowance);
+                            deathReason = PopulationChangeReason.Timeout;
+                            bug.Active = false;
+                        }
+                        else if (bug.Overage > MaxOverage)
+                        {
+                            bug.Overage -= Quantum;
+                            if (bug.Overage < 0) bug.Overage = 0;
+
+                            bug.Organism.InternalMain(true);
+                            bug.Organism.WriteTrace(
+                                $"Animal's turn was skipped because they took longer than {Quantum} microseconds for their turn too many times.");
+
+                            success = true;
+                            skippedTurn = true;
+                        }
+                        else
+                        {
+                            cts.CancelAfter(TimeSpan.FromMilliseconds(1000));
+
+                            _monitor.Start();
+
+                            // Run organism code
+                            bug.Organism.InternalMain(false);
+
+                            duration = _monitor.EndGetMicroseconds();
+                            success = true;
+                        }
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        deathReason = PopulationChangeReason.Timeout;
+                        _logger.LogWarning("Organism timed out via cancellation.");
+                    }
+                    catch (Exception e) when (e is not MaliciousOrganismException)
+                    {
+                        deathReason = PopulationChangeReason.Error;
+                        exceptionInfo = e.ToString();
+                    }
+                    finally
+                    {
+                        _timeoutCts = null;
+
+                        if (!success)
+                        {
+                            if (_currentEngine != null)
+                            {
+                                _currentEngine.RemoveOrganismQueued(
+                                    deathReason == PopulationChangeReason.Timeout
+                                        ? new KilledOrganism(bug.Organism.ID, deathReason)
+                                        : new KilledOrganism(bug.Organism.ID, deathReason, exceptionInfo));
+
+                                if (deathReason != PopulationChangeReason.Timeout)
+                                {
+                                    _logger.LogWarning("Exception in organism: {Info}", exceptionInfo);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            _totalActivations++;
+                            if (PenalizeForTime)
+                            {
+                                bug.TotalTime += duration;
+                                bug.LastTime = duration;
+                                if (duration > Quantum)
+                                {
+                                    bug.Overage += (duration - Quantum);
+                                }
+                                else if (bug.Overage > 0 && !skippedTurn)
+                                {
+                                    bug.Overage -= (Quantum - duration);
+                                    if (bug.Overage < 0) bug.Overage = 0;
+                                }
+                            }
+                            else
+                            {
+                                bug.LastTime = duration;
+                                bug.Overage = 0;
+                            }
+
+                            bug.TotalActivations++;
+                        }
+
+                        if (_totalActivations > _lastReport + ReportInterval)
+                        {
+                            _lastReport = _totalActivations;
+                        }
+                    }
+                }
+            }
+
+            // Signal that this organism is done
+            try { _completionGate.Release(); }
+            catch (SemaphoreFullException) { /* already signaled */ }
+        }
+    }
+
+    /// <summary>
+    /// Shuts down the scheduler and releases resources.
+    /// </summary>
+    public void Close()
+    {
+        _exitRequested = true;
+        try { _activationGate.Release(); }
+        catch (SemaphoreFullException) { }
+
+        _activationTask?.Wait(TimeSpan.FromSeconds(5));
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        Close();
+        _activationGate.Dispose();
+        _completionGate.Dispose();
+        _timeoutCts?.Dispose();
+    }
+
+    // --- Inner types ---
+
+    /// <summary>
+    /// Wraps an organism with timing and status metadata.
+    /// </summary>
+    internal sealed class OrganismWrapper
+    {
+        public OrganismWrapper(Organism organism, string id)
+        {
+            Organism = organism;
+            ID = id;
+        }
+
+        public Organism Organism { get; }
+        public string ID { get; }
+        public bool Active { get; set; } = true;
+        public long Overage { get; set; }
+        public long TotalTime { get; set; }
+        public long LastTime { get; set; }
+        public long TotalActivations { get; set; }
+    }
+
+    /// <summary>
+    /// Exception thrown when a malicious or deadlocked organism is detected.
+    /// </summary>
+    public class MaliciousOrganismException : Exception
+    {
+        public MaliciousOrganismException() : base("A malicious organism was detected.") { }
+        public MaliciousOrganismException(string message) : base(message) { }
+        public MaliciousOrganismException(string message, Exception inner) : base(message, inner) { }
+    }
+}

--- a/src/Terrarium.Game/Hosting/PrivateAssemblyCache.cs
+++ b/src/Terrarium.Game/Hosting/PrivateAssemblyCache.cs
@@ -1,0 +1,473 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
+
+namespace Terrarium.Game.Hosting;
+
+/// <summary>
+/// Manages the local cache of creature DLL assemblies. Stores organism
+/// assemblies in an obfuscated directory, provides assembly resolution via
+/// <see cref="AssemblyLoadContext"/>, and enforces blacklisting by replacing
+/// assemblies with zero-length files.
+/// </summary>
+public sealed class PrivateAssemblyCache : IDisposable
+{
+    private static readonly string _versionDirectoryPreamble;
+
+    private readonly ILogger<PrivateAssemblyCache> _logger;
+    private readonly Dictionary<string, string> _loadedAssemblies = new();
+    private readonly OrganismAssemblyLoadContext _loadContext;
+
+    private string _dataFile;
+    private string _dataPath;
+    private bool _hookAssemblyResolve;
+    private long _pacSize;
+    private bool _trackLastRun = true;
+    private bool _disposed;
+
+    static PrivateAssemblyCache()
+    {
+        var version = Assembly.GetExecutingAssembly().GetName().Version ?? new Version(1, 0, 0);
+        _versionDirectoryPreamble = $"{version.Major}.{version.Minor}.{version.Build}";
+    }
+
+    /// <summary>
+    /// Creates a new private assembly cache.
+    /// </summary>
+    public PrivateAssemblyCache(
+        string dataPath,
+        string dataFile,
+        ILogger<PrivateAssemblyCache> logger,
+        bool hookAssemblyResolve = true,
+        bool trackLastRun = true)
+    {
+        _logger = logger;
+        _trackLastRun = trackLastRun;
+        _dataPath = string.IsNullOrEmpty(dataPath) ? Path.GetFullPath(".") : Path.GetFullPath(dataPath);
+        _dataFile = Path.GetFileName(dataFile);
+        _hookAssemblyResolve = hookAssemblyResolve;
+
+        if (!Directory.Exists(BaseAssemblyDirectory))
+        {
+            Directory.CreateDirectory(BaseAssemblyDirectory);
+        }
+
+        _loadContext = new OrganismAssemblyLoadContext(AssemblyDirectory, _logger);
+
+        if (hookAssemblyResolve)
+        {
+            HookAssemblyResolve();
+        }
+    }
+
+    /// <summary>Event raised when assemblies in the PAC change.</summary>
+    public event EventHandler? PacAssembliesChanged;
+
+    /// <summary>Path to the assembly cache directory.</summary>
+    public string AssemblyDirectory => BaseAssemblyDirectory;
+
+    private string BaseAssemblyDirectory => GetBaseAssemblyDirectory(_dataPath, _dataFile);
+
+    /// <summary>Approximate size in bytes of all loaded assemblies.</summary>
+    public long PacSize => _pacSize;
+
+    /// <summary>Number of organisms loaded from the PAC.</summary>
+    public int PacOrganismCount => _loadedAssemblies.Count;
+
+    /// <summary>The versioned directory preamble for cache paths.</summary>
+    public static string VersionedDirectoryPreamble => _versionDirectoryPreamble;
+
+    /// <summary>
+    /// Tracks which organism was running when Terrarium last shut down,
+    /// enabling post-crash blacklisting.
+    /// </summary>
+    public string LastRun
+    {
+        get
+        {
+            var filePath = Path.Combine(AssemblyDirectory, "data.dat");
+            try
+            {
+                if (!File.Exists(filePath)) return "";
+                using var stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using var reader = new BinaryReader(stream);
+                return stream.Length == 0 ? "" : reader.ReadString();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to read LastRun file.");
+                return "";
+            }
+        }
+        set
+        {
+            var filePath = Path.Combine(AssemblyDirectory, "data.dat");
+            if (_trackLastRun || value.Length == 0)
+            {
+                try
+                {
+                    using var stream = File.Open(filePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.None);
+                    using var writer = new BinaryWriter(stream);
+                    writer.Write(value);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Failed to write LastRun file.");
+                }
+            }
+        }
+    }
+
+    /// <summary>Hooks assembly resolution for the custom load context.</summary>
+    public void HookAssemblyResolve()
+    {
+        if (_hookAssemblyResolve)
+        {
+            _logger.LogDebug("Assembly resolve hooked via AssemblyLoadContext.");
+        }
+    }
+
+    /// <summary>Unhooks assembly resolve and releases resources.</summary>
+    public void Close()
+    {
+        _logger.LogDebug("PrivateAssemblyCache closed.");
+    }
+
+    /// <summary>Generates a file name for the given assembly full name.</summary>
+    public string GetFileName(string fullName)
+    {
+        return Path.Combine(AssemblyDirectory, GetAssemblyShortName(fullName) + ".dll");
+    }
+
+    /// <summary>Extracts the short name from an assembly full name.</summary>
+    public static string GetAssemblyShortName(string fullName)
+    {
+        var chunks = fullName.Split(',');
+        return chunks[0].ToLower(CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>Extracts the version string from an assembly full name.</summary>
+    public static string GetAssemblyVersion(string fullName)
+    {
+        var chunks = fullName.Split(',');
+        var versionPieces = chunks[1].Split('=');
+        return versionPieces[1];
+    }
+
+    /// <summary>Computes the base assembly directory from a path and data file name.</summary>
+    public static string GetBaseAssemblyDirectory(string dataPath, string dataFile)
+    {
+        var dataFilePart = dataFile[..dataFile.LastIndexOf('.')];
+        return Path.Combine(dataPath, dataFilePart + "_Assemblies");
+    }
+
+    /// <summary>
+    /// Blacklists assemblies by replacing them with zero-length files,
+    /// preventing them from being loaded or replaced with fresh copies.
+    /// </summary>
+    public void BlacklistAssemblies(string[]? assemblies)
+    {
+        if (assemblies == null) return;
+
+        foreach (var assembly in assemblies)
+        {
+            var fileName = GetFileName(assembly);
+            try
+            {
+                var fullPath = Path.GetFullPath(fileName);
+                if (!fullPath.StartsWith(Path.GetFullPath(AssemblyDirectory), StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogWarning("Blocked blacklist attempt outside assembly directory: {Path}", fullPath);
+                    continue;
+                }
+
+                using var stream = File.Create(fileName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error blacklisting organism assembly: {Assembly}", assembly);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads an organism assembly via <see cref="AssemblyLoadContext"/>.
+    /// </summary>
+    public Assembly LoadOrganismAssembly(string fullName)
+    {
+        if (!_loadedAssemblies.ContainsKey(fullName))
+        {
+            _loadedAssemblies[fullName] = fullName;
+            var fileInfo = new FileInfo(GetFileName(fullName));
+            if (fileInfo.Exists)
+            {
+                _pacSize += fileInfo.Length;
+            }
+        }
+
+        var assemblyPath = GetFileName(fullName);
+        return _loadContext.LoadFromAssemblyPath(Path.GetFullPath(assemblyPath));
+    }
+
+    /// <summary>Checks whether the assembly exists in the PAC.</summary>
+    public bool Exists(string fullName)
+    {
+        var fileName = GetFileName(fullName);
+        var fullPath = Path.GetFullPath(fileName);
+
+        if (!fullPath.StartsWith(Path.GetFullPath(AssemblyDirectory), StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return File.Exists(fullPath);
+    }
+
+    /// <summary>Saves raw assembly bytes to the PAC.</summary>
+    public async Task SaveOrganismBytesAsync(byte[] bytes, string fullName, CancellationToken cancellationToken = default)
+    {
+        EnsureDirectoryExists();
+
+        var fileName = GetFileName(fullName);
+        if (File.Exists(fileName)) return;
+
+        ValidatePathSecurity(fileName);
+
+        try
+        {
+            await using var targetStream = File.Create(fileName);
+            await targetStream.WriteAsync(bytes, cancellationToken);
+        }
+        catch
+        {
+            if (File.Exists(fileName)) File.Delete(fileName);
+            throw;
+        }
+
+        OnPacAssembliesChanged();
+    }
+
+    /// <summary>Saves raw assembly bytes to the PAC (synchronous).</summary>
+    public void SaveOrganismBytes(byte[] bytes, string fullName)
+    {
+        EnsureDirectoryExists();
+
+        var fileName = GetFileName(fullName);
+        if (File.Exists(fileName)) return;
+
+        ValidatePathSecurity(fileName);
+
+        try
+        {
+            using var targetStream = File.Create(fileName);
+            targetStream.Write(bytes, 0, bytes.Length);
+        }
+        catch
+        {
+            if (File.Exists(fileName)) File.Delete(fileName);
+            throw;
+        }
+
+        OnPacAssembliesChanged();
+    }
+
+    /// <summary>
+    /// Saves an assembly from a file path, optionally with symbols.
+    /// Validates the assembly before saving.
+    /// </summary>
+    public async Task SaveOrganismAssemblyAsync(
+        string assemblyPath,
+        string fullName,
+        string? symbolPath = null,
+        AssemblyValidator? validator = null,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureDirectoryExists();
+
+        var fileName = GetFileName(fullName);
+        if (File.Exists(fileName)) return;
+
+        if (validator != null)
+        {
+            var result = validator.Validate(assemblyPath);
+            if (!result.IsValid)
+            {
+                throw new InvalidOperationException(
+                    $"Assembly failed validation: {string.Join("; ", result.Reasons)}");
+            }
+        }
+
+        ValidatePathSecurity(fileName);
+
+        await using (var sourceStream = File.OpenRead(assemblyPath))
+        {
+            try
+            {
+                await using var targetStream = File.Create(fileName);
+                await sourceStream.CopyToAsync(targetStream, cancellationToken);
+            }
+            catch
+            {
+                if (File.Exists(fileName)) File.Delete(fileName);
+                throw;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(symbolPath) && File.Exists(symbolPath))
+        {
+            var symName = Path.ChangeExtension(fileName, ".pdb");
+            try
+            {
+                await using var symSource = File.OpenRead(symbolPath);
+                await using var symTarget = File.Create(symName);
+                await symSource.CopyToAsync(symTarget, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to copy symbols for {Assembly}.", fullName);
+            }
+        }
+
+        OnPacAssembliesChanged();
+    }
+
+    /// <summary>Returns info about all valid assemblies in the cache.</summary>
+    public OrganismAssemblyInfo[] GetAssemblies()
+    {
+        if (!Directory.Exists(AssemblyDirectory))
+        {
+            return [];
+        }
+
+        var infoList = new List<OrganismAssemblyInfo>();
+        foreach (var fileName in Directory.GetFiles(AssemblyDirectory, "*.dll"))
+        {
+            var info = new FileInfo(fileName);
+            if (info.Length <= 0) continue;
+
+            try
+            {
+                var assembly = _loadContext.LoadFromAssemblyPath(Path.GetFullPath(fileName));
+                infoList.Add(new OrganismAssemblyInfo(assembly.FullName!, GetAssemblyShortName(assembly.FullName!)));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to load assembly info for {File}.", fileName);
+            }
+        }
+
+        return infoList.ToArray();
+    }
+
+    /// <summary>Returns assembly short names of all blacklisted (zero-length) assemblies.</summary>
+    public string[] GetBlacklistedAssemblies()
+    {
+        var blacklisted = new List<string>();
+
+        if (!Directory.Exists(AssemblyDirectory)) return [];
+
+        foreach (var fileName in Directory.GetFiles(AssemblyDirectory, "*.dll"))
+        {
+            var info = new FileInfo(fileName);
+            if (info.Length == 0)
+            {
+                blacklisted.Add(Path.GetFileNameWithoutExtension(fileName));
+            }
+        }
+
+        return blacklisted.ToArray();
+    }
+
+    /// <summary>Creates a temp file path that can't be guessed.</summary>
+    public static string GetSafeTempFileName()
+    {
+        return Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        Close();
+    }
+
+    // --- Helpers ---
+
+    private void EnsureDirectoryExists()
+    {
+        if (!Directory.Exists(AssemblyDirectory))
+        {
+            Directory.CreateDirectory(AssemblyDirectory);
+        }
+    }
+
+    private void ValidatePathSecurity(string fileName)
+    {
+        var fullPath = Path.GetFullPath(fileName);
+        if (!fullPath.StartsWith(Path.GetFullPath(AssemblyDirectory), StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Path traversal detected: '{fullPath}' is outside the assembly directory.");
+        }
+    }
+
+    private void OnPacAssembliesChanged()
+    {
+        PacAssembliesChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    // --- Inner types ---
+
+    /// <summary>
+    /// Custom <see cref="AssemblyLoadContext"/> for isolating organism assemblies.
+    /// </summary>
+    private sealed class OrganismAssemblyLoadContext : AssemblyLoadContext
+    {
+        private readonly string _assemblyDirectory;
+        private readonly ILogger _logger;
+
+        public OrganismAssemblyLoadContext(string assemblyDirectory, ILogger logger)
+            : base("OrganismContext", isCollectible: true)
+        {
+            _assemblyDirectory = assemblyDirectory;
+            _logger = logger;
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            var shortName = assemblyName.Name?.ToLower(CultureInfo.InvariantCulture);
+            if (shortName == null) return null;
+
+            var candidatePath = Path.Combine(_assemblyDirectory, shortName + ".dll");
+            if (File.Exists(candidatePath))
+            {
+                var info = new FileInfo(candidatePath);
+                if (info.Length > 0)
+                {
+                    _logger.LogDebug("Loading organism assembly: {Path}", candidatePath);
+                    return LoadFromAssemblyPath(Path.GetFullPath(candidatePath));
+                }
+            }
+
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// Stores assembly metadata for display.
+/// </summary>
+public sealed class OrganismAssemblyInfo
+{
+    public OrganismAssemblyInfo(string fullName, string shortName)
+    {
+        FullName = fullName;
+        ShortName = shortName;
+    }
+
+    public string FullName { get; }
+    public string ShortName { get; }
+}


### PR DESCRIPTION
## Sprint 6: Security

Closes #44, #45, #46

- GameScheduler: Creature execution scheduling with time quanta
- PrivateAssemblyCache: Assembly storage with AssemblyLoadContext
- AssemblyValidator: Managed IL validation replacing C++ AsmCheck