### PR TITLE
Organism isolation architecture — AssemblyLoadContext sandbox

### DIFF
--- a/.ai-team/decisions/inbox/heisenberg-isolation-architecture.md
+++ b/.ai-team/decisions/inbox/heisenberg-isolation-architecture.md
@@ -1,0 +1,101 @@
+# Decision: Organism Isolation Architecture
+
+**Author:** Heisenberg (Lead Architect)
+**Date:** 2025-07-16
+**Status:** Proposed
+**Issue:** #43
+
+## Context
+
+The legacy Terrarium used `AppDomain`-based isolation (`OrganismWrapper`, `TerrariumOrganism`, `GameScheduler`) to execute untrusted creature code safely. .NET 10 removes AppDomains entirely. We need a modern replacement that provides:
+
+1. **Assembly isolation** - creature assemblies must not interfere with each other or the host
+2. **Safe execution** - timeout enforcement, exception containment, CPU fairness
+3. **Memory management** - ability to unload creature code when species are removed
+4. **Static analysis** - pre-load validation to reject obviously dangerous assemblies
+
+## Decision
+
+We implement a three-layer isolation architecture using **AssemblyLoadContext** as the primary isolation boundary:
+
+### Layer 1: Static Validation (`CreatureValidator`)
+Before any assembly is loaded, we perform metadata-level inspection using `System.Reflection.Metadata` to detect:
+- P/Invoke declarations (native interop)
+- Forbidden type references (file I/O, networking, process spawning, reflection emit)
+- Missing required base class (must inherit `Animal` or `Plant`)
+- Missing required attributes (`AuthorInformationAttribute`)
+
+### Layer 2: Load Isolation (`OrganismSandbox`)
+Each creature assembly type gets its own **collectible `AssemblyLoadContext`**:
+- Assemblies are loaded from `byte[]` (no file locks)
+- Contexts are collectible (`isCollectible: true`), enabling full unload
+- Shared framework types (OrganismBase, BCL) resolve from the default context
+- When a species is removed, its context is unloaded to reclaim memory
+
+### Layer 3: Execution Safety (`OrganismHost` + `OrganismScheduler`)
+- `OrganismHost.ExecuteTurn()` wraps each creature's `InternalMain()` with:
+  - `CancellationTokenSource` timeout
+  - `Task.Run` + `Task.Wait` for wall-clock enforcement
+  - Full exception containment
+  - CPU time measurement via `Stopwatch`
+- `OrganismScheduler` provides fair round-robin scheduling:
+  - Organisms divided into 5 batches (one per engine phase 0-4)
+  - `OrganismQuanta` tracks per-creature CPU usage
+  - Creatures exceeding quantum get reduced time in subsequent ticks
+
+## Alternatives Considered
+
+### Worker Process Isolation
+**Pros:** True OS-level isolation, can enforce memory limits via process boundaries, crash containment
+**Cons:**
+- Massive serialization overhead (OrganismState, PendingActions, WorldState must cross process boundary every tick)
+- 10-phase ProcessTurn design assumes in-process organism access
+- Latency: 5 ticks/sec x hundreds of organisms x IPC round-trips = unacceptable
+- Complexity: process lifecycle management, crash recovery, shared memory regions
+
+**Verdict:** Too much overhead for the Terrarium's tight game loop. The legacy system was in-process for good reason.
+
+### WebAssembly (WASM) Sandbox
+**Pros:** Strong isolation, deterministic execution
+**Cons:**
+- Creatures are .NET assemblies; would require compilation to WASM
+- No mature .NET-to-WASM-sandbox runtime for server-side use
+- Would break the existing creature development workflow
+
+**Verdict:** Interesting future direction but not practical today.
+
+### Roslyn Scripting API
+**Pros:** Fine-grained API restriction
+**Cons:**
+- Creatures are compiled assemblies, not scripts
+- Would require rewriting the creature development model
+- Performance overhead of interpretation
+
+**Verdict:** Wrong abstraction level.
+
+## Security Tradeoffs
+
+| Risk | Mitigation | Residual Risk |
+|------|-----------|---------------|
+| Creature uses reflection to bypass restrictions | `CreatureValidator` blocks `System.Reflection.Emit`; runtime restrictions via ALC | Medium |
+| CPU starvation (infinite loop) | `OrganismHost` timeout + `OrganismQuanta` penalties | Low |
+| Memory exhaustion | Collectible ALC enables unload; future: per-creature memory tracking | Medium |
+| Thread spawning | `CreatureValidator` blocks `System.Threading` namespace | Medium |
+| File system access | `CreatureValidator` blocks `System.IO` namespace | Low |
+
+## Future Considerations
+
+1. **Process isolation (Phase 2):** For tournament/competitive scenarios, wrap the ALC-based sandbox inside a worker process for true containment. The `IOrganismScheduler` interface makes this swappable.
+2. **Memory budgets:** Add per-ALC memory tracking using `AssemblyLoadContext` events and GC notifications.
+3. **IL rewriting:** Use Cecil/Mono.Cecil to rewrite creature IL at load time, injecting cancellation checks at loop back-edges for cooperative cancellation.
+4. **Allowlist approach:** Instead of blocking known-bad APIs, switch to an allowlist of permitted types for stronger guarantees.
+5. **Runtime CAS replacement:** Investigate `System.Security.Permissions` polyfill or custom security transparent enforcement.
+
+## Implementation Files
+
+- `src/Terrarium.Game/Hosting/CreatureValidator.cs` - Static assembly validation + ValidationResult
+- `src/Terrarium.Game/Hosting/OrganismSandbox.cs` - AssemblyLoadContext isolation
+- `src/Terrarium.Game/Hosting/OrganismHost.cs` - Safe turn execution with timeout
+- `src/Terrarium.Game/Hosting/OrganismQuanta.cs` - CPU time tracking and penalties
+- `src/Terrarium.Game/Hosting/IOrganismScheduler.cs` - Scheduler interface
+- `src/Terrarium.Game/Hosting/OrganismScheduler.cs` - Fair round-robin implementation

--- a/src/Terrarium.Game/Hosting/CreatureValidator.cs
+++ b/src/Terrarium.Game/Hosting/CreatureValidator.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using OrganismBase;
+
+namespace Terrarium.Game.Hosting;
+
+/// <summary>
+/// Structured result of assembly validation.
+/// </summary>
+public sealed class ValidationResult
+{
+    public bool IsValid { get; }
+    public IReadOnlyList<string> Reasons { get; }
+
+    private ValidationResult(bool isValid, IReadOnlyList<string> reasons)
+    {
+        IsValid = isValid;
+        Reasons = reasons;
+    }
+
+    public static ValidationResult Pass() => new(true, Array.Empty<string>());
+    public static ValidationResult Fail(IReadOnlyList<string> reasons) => new(false, reasons);
+}
+
+/// <summary>
+/// Static analysis of creature assemblies before loading.
+/// Inspects IL metadata for forbidden patterns (P/Invoke, unsafe, forbidden namespaces),
+/// validates creature base type (Animal or Plant), and checks required attributes.
+/// </summary>
+public sealed class CreatureValidator
+{
+    private static readonly string[] ForbiddenNamespaces =
+    [
+        "System.IO",
+        "System.Net",
+        "System.Diagnostics.Process",
+        "System.Runtime.InteropServices",
+        "System.Reflection.Emit",
+        "System.Threading",
+        "System.Security",
+        "Microsoft.Win32",
+    ];
+
+    /// <summary>
+    /// Validates a creature assembly from raw bytes.
+    /// Performs metadata-level IL checks, then loads to verify base class and attributes.
+    /// </summary>
+    public ValidationResult Validate(byte[] assemblyBytes)
+    {
+        if (assemblyBytes == null || assemblyBytes.Length == 0)
+            return ValidationResult.Fail(["Assembly bytes are null or empty."]);
+
+        var errors = new List<string>();
+
+        try
+        {
+            using var stream = new MemoryStream(assemblyBytes);
+            using var peReader = new PEReader(stream);
+
+            if (!peReader.HasMetadata)
+                return ValidationResult.Fail(["Assembly does not contain managed metadata."]);
+
+            var reader = peReader.GetMetadataReader();
+            CheckForPInvoke(reader, errors);
+            CheckForbiddenNamespaces(reader, errors);
+            CheckInheritanceChain(reader, errors);
+        }
+        catch (BadImageFormatException ex)
+        {
+            return ValidationResult.Fail([$"Invalid assembly format: {ex.Message}"]);
+        }
+
+        if (errors.Count == 0)
+        {
+            try
+            {
+                var assembly = Assembly.Load(assemblyBytes);
+                CheckCreatureBaseType(assembly, errors);
+                CheckRequiredAttributes(assembly, errors);
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"Failed to inspect assembly: {ex.Message}");
+            }
+        }
+
+        return errors.Count == 0
+            ? ValidationResult.Pass()
+            : ValidationResult.Fail(errors);
+    }
+
+    private static void CheckForPInvoke(MetadataReader reader, List<string> errors)
+    {
+        foreach (var methodHandle in reader.MethodDefinitions)
+        {
+            var method = reader.GetMethodDefinition(methodHandle);
+            if ((method.Attributes & MethodAttributes.PinvokeImpl) != 0)
+            {
+                var name = reader.GetString(method.Name);
+                var declaringType = reader.GetTypeDefinition(method.GetDeclaringType());
+                var typeName = reader.GetString(declaringType.Name);
+                var typeNamespace = reader.GetString(declaringType.Namespace);
+                errors.Add($"Forbidden P/Invoke declaration: {typeNamespace}.{typeName}.{name}");
+            }
+
+            if ((method.ImplAttributes & MethodImplAttributes.Unmanaged) != 0 ||
+                (method.ImplAttributes & MethodImplAttributes.Native) != 0)
+            {
+                var name = reader.GetString(method.Name);
+                errors.Add($"Forbidden unmanaged/native method: {name}");
+            }
+        }
+    }
+
+    private static void CheckForbiddenNamespaces(MetadataReader reader, List<string> errors)
+    {
+        foreach (var typeRefHandle in reader.TypeReferences)
+        {
+            var typeRef = reader.GetTypeReference(typeRefHandle);
+            var ns = reader.GetString(typeRef.Namespace);
+            var name = reader.GetString(typeRef.Name);
+
+            foreach (var forbidden in ForbiddenNamespaces)
+            {
+                if (ns.Equals(forbidden, StringComparison.Ordinal) ||
+                    ns.StartsWith(forbidden + ".", StringComparison.Ordinal))
+                {
+                    errors.Add($"Forbidden namespace reference: {ns}.{name}");
+                    break;
+                }
+            }
+        }
+    }
+
+    private static readonly HashSet<string> AllowedBaseTypes = new(StringComparer.Ordinal)
+    {
+        "OrganismBase.Animal",
+        "OrganismBase.Plant",
+    };
+
+    private static void CheckInheritanceChain(MetadataReader reader, List<string> errors)
+    {
+        var hasValidBase = false;
+
+        foreach (var typeDefHandle in reader.TypeDefinitions)
+        {
+            var typeDef = reader.GetTypeDefinition(typeDefHandle);
+            if ((typeDef.Attributes & TypeAttributes.Public) == 0) continue;
+            if ((typeDef.Attributes & TypeAttributes.Abstract) != 0) continue;
+
+            if (HasAllowedBaseType(reader, typeDef))
+            {
+                hasValidBase = true;
+                break;
+            }
+        }
+
+        if (!hasValidBase)
+        {
+            errors.Add("No public non-abstract type found that extends OrganismBase.Animal or OrganismBase.Plant.");
+        }
+    }
+
+    private static bool HasAllowedBaseType(MetadataReader reader, TypeDefinition typeDef)
+    {
+        var baseTypeHandle = typeDef.BaseType;
+
+        for (var depth = 0; depth < 20 && !baseTypeHandle.IsNil; depth++)
+        {
+            switch (baseTypeHandle.Kind)
+            {
+                case HandleKind.TypeReference:
+                    var typeRef = reader.GetTypeReference((TypeReferenceHandle)baseTypeHandle);
+                    var baseNs = reader.GetString(typeRef.Namespace);
+                    var baseName = reader.GetString(typeRef.Name);
+                    return AllowedBaseTypes.Contains($"{baseNs}.{baseName}");
+
+                case HandleKind.TypeDefinition:
+                    var baseTypeDef = reader.GetTypeDefinition((TypeDefinitionHandle)baseTypeHandle);
+                    var ns = reader.GetString(baseTypeDef.Namespace);
+                    var name = reader.GetString(baseTypeDef.Name);
+                    if (AllowedBaseTypes.Contains($"{ns}.{name}")) return true;
+                    baseTypeHandle = baseTypeDef.BaseType;
+                    break;
+
+                default:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static void CheckCreatureBaseType(Assembly assembly, List<string> errors)
+    {
+        var creatureTypes = assembly.GetExportedTypes()
+            .Where(t => t.IsClass && !t.IsAbstract &&
+                        (typeof(Animal).IsAssignableFrom(t) || typeof(Plant).IsAssignableFrom(t)))
+            .ToList();
+
+        if (creatureTypes.Count == 0)
+        {
+            errors.Add("Assembly must contain at least one non-abstract class inheriting from Animal or Plant.");
+        }
+    }
+
+    private static void CheckRequiredAttributes(Assembly assembly, List<string> errors)
+    {
+        var authorAttr = assembly.GetCustomAttributes()
+            .FirstOrDefault(a => a.GetType() == typeof(AuthorInformationAttribute));
+
+        if (authorAttr == null)
+        {
+            errors.Add("Assembly must have an [assembly: AuthorInformation] attribute.");
+        }
+    }
+}

--- a/src/Terrarium.Game/Hosting/IOrganismScheduler.cs
+++ b/src/Terrarium.Game/Hosting/IOrganismScheduler.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using OrganismBase;
+
+namespace Terrarium.Game.Hosting;
+
+/// <summary>
+/// Interface for organism scheduling. Manages turn-taking for all
+/// organisms in the terrarium, enforcing fair CPU time distribution.
+/// </summary>
+public interface IOrganismScheduler
+{
+    /// <summary>
+    /// All organisms currently managed by the scheduler.
+    /// </summary>
+    IReadOnlyCollection<Organism> Organisms { get; }
+
+    /// <summary>
+    /// The current world state used by the scheduler.
+    /// Updated at the end of each tick by the game engine.
+    /// </summary>
+    WorldState? CurrentState { get; set; }
+
+    /// <summary>
+    /// Creates and registers a new organism of the given type.
+    /// </summary>
+    /// <param name="creatureType">The CLR type of the creature to instantiate.</param>
+    /// <param name="id">The organism ID to assign.</param>
+    /// <returns>The created organism instance, or null if creation failed.</returns>
+    Organism? Create(Type creatureType, string id);
+
+    /// <summary>
+    /// Removes an organism from the scheduler.
+    /// </summary>
+    /// <param name="id">The organism ID to remove.</param>
+    void Remove(string id);
+
+    /// <summary>
+    /// Processes one scheduling tick: gives a slice of organisms their turn.
+    /// Called 5 times per game tick (phases 0-4), each time processing
+    /// roughly 1/5 of all organisms.
+    /// </summary>
+    void Tick();
+
+    /// <summary>
+    /// Gets the organism instance by ID.
+    /// </summary>
+    /// <param name="id">The organism ID.</param>
+    /// <returns>The organism, or null if not found.</returns>
+    Organism? GetOrganism(string id);
+
+    /// <summary>
+    /// Gets the quanta tracking for a specific organism.
+    /// </summary>
+    /// <param name="id">The organism ID.</param>
+    /// <returns>The quanta tracker, or null if not found.</returns>
+    OrganismQuanta? GetQuanta(string id);
+
+    /// <summary>
+    /// Destroys the scheduler and releases all resources.
+    /// </summary>
+    void Destroy();
+}

--- a/src/Terrarium.Game/Hosting/OrganismHost.cs
+++ b/src/Terrarium.Game/Hosting/OrganismHost.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using OrganismBase;
+
+namespace Terrarium.Game.Hosting;
+
+/// <summary>
+/// The result of executing a creature's turn.
+/// </summary>
+public sealed class OrganismTurnResult
+{
+    /// <summary>The actions the creature wants to perform.</summary>
+    public PendingActions Actions { get; init; } = new();
+
+    /// <summary>CPU time consumed during the turn.</summary>
+    public TimeSpan CpuTimeUsed { get; init; }
+
+    /// <summary>Whether the creature's turn completed successfully.</summary>
+    public bool Completed { get; init; }
+
+    /// <summary>If the turn failed, the reason why.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Whether the creature exceeded its time quantum.</summary>
+    public bool TimedOut { get; init; }
+}
+
+/// <summary>
+/// Wraps creature execution with safety controls.
+/// Runs the creature's think method with timeout enforcement,
+/// exception handling, and CPU time measurement.
+/// </summary>
+public sealed class OrganismHost
+{
+    private readonly ILogger<OrganismHost> _logger;
+
+    public OrganismHost(ILogger<OrganismHost> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Executes a creature's turn (calls InternalMain) with timeout and exception safety.
+    /// </summary>
+    /// <param name="organism">The organism to execute.</param>
+    /// <param name="timeout">Maximum wall-clock time allowed for the turn.</param>
+    /// <param name="clearOnly">If true, the creature clears state without acting.</param>
+    /// <returns>The result of the turn execution.</returns>
+    public OrganismTurnResult ExecuteTurn(Organism organism, TimeSpan timeout, bool clearOnly = false)
+    {
+        if (organism == null)
+            throw new ArgumentNullException(nameof(organism));
+
+        var sw = Stopwatch.StartNew();
+        using var cts = new CancellationTokenSource(timeout);
+
+        try
+        {
+            var task = Task.Run(() => organism.InternalMain(clearOnly), cts.Token);
+
+            if (task.Wait(timeout))
+            {
+                sw.Stop();
+                var actions = organism.GetThenErasePendingActions();
+                return new OrganismTurnResult
+                {
+                    Actions = actions,
+                    CpuTimeUsed = sw.Elapsed,
+                    Completed = true
+                };
+            }
+            else
+            {
+                sw.Stop();
+                cts.Cancel();
+                _logger.LogWarning("Organism {ID} exceeded time quantum ({Timeout}ms)",
+                    organism.ID, timeout.TotalMilliseconds);
+
+                var actions = organism.GetThenErasePendingActions();
+                return new OrganismTurnResult
+                {
+                    Actions = actions,
+                    CpuTimeUsed = sw.Elapsed,
+                    Completed = false,
+                    TimedOut = true,
+                    ErrorMessage = $"Turn exceeded time quantum of {timeout.TotalMilliseconds}ms"
+                };
+            }
+        }
+        catch (AggregateException ex) when (ex.InnerException is OperationCanceledException)
+        {
+            sw.Stop();
+            _logger.LogWarning("Organism {ID} turn was cancelled", organism.ID);
+            var actions = organism.GetThenErasePendingActions();
+            return new OrganismTurnResult
+            {
+                Actions = actions,
+                CpuTimeUsed = sw.Elapsed,
+                Completed = false,
+                TimedOut = true,
+                ErrorMessage = "Turn was cancelled due to timeout"
+            };
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            _logger.LogError(ex, "Organism {ID} threw an exception during its turn", organism.ID);
+            var actions = organism.GetThenErasePendingActions();
+            return new OrganismTurnResult
+            {
+                Actions = actions,
+                CpuTimeUsed = sw.Elapsed,
+                Completed = false,
+                ErrorMessage = $"Creature exception: {ex.GetBaseException().Message}"
+            };
+        }
+    }
+}

--- a/src/Terrarium.Game/Hosting/OrganismQuanta.cs
+++ b/src/Terrarium.Game/Hosting/OrganismQuanta.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Diagnostics;
+
+namespace Terrarium.Game.Hosting;
+
+/// <summary>
+/// CPU time measurement for fair scheduling of organisms.
+/// Each creature gets a time quantum per tick. This class tracks
+/// cumulative CPU usage and applies penalties for overuse.
+/// Ported from the legacy OrganismQuanta with modern APIs.
+/// </summary>
+public sealed class OrganismQuanta
+{
+    /// <summary>Default quantum in milliseconds per tick.</summary>
+    public const int DefaultQuantumMs = 5;
+
+    /// <summary>Maximum penalty multiplier for creatures that exceed their quantum.</summary>
+    public const int MaxPenaltyMultiplier = 3;
+
+    private readonly object _lock = new();
+    private readonly Stopwatch _stopwatch = new();
+
+    private long _totalTicksConsumed;
+    private int _totalActivations;
+    private long _lastTicksConsumed;
+    private int _penaltyMultiplier;
+    private long _overageTicks;
+
+    /// <summary>Total CPU ticks consumed across all activations.</summary>
+    public long TotalTicksConsumed { get { lock (_lock) return _totalTicksConsumed; } }
+
+    /// <summary>CPU ticks consumed during the last activation.</summary>
+    public long LastTicksConsumed { get { lock (_lock) return _lastTicksConsumed; } }
+
+    /// <summary>Total number of activations (turns executed).</summary>
+    public int TotalActivations { get { lock (_lock) return _totalActivations; } }
+
+    /// <summary>Cumulative overage ticks beyond the quantum.</summary>
+    public long OverageTicks { get { lock (_lock) return _overageTicks; } }
+
+    /// <summary>Current penalty multiplier (0 = no penalty).</summary>
+    public int PenaltyMultiplier { get { lock (_lock) return _penaltyMultiplier; } }
+
+    /// <summary>Average CPU time per activation.</summary>
+    public TimeSpan AverageTimePerActivation
+    {
+        get
+        {
+            lock (_lock)
+            {
+                if (_totalActivations == 0) return TimeSpan.Zero;
+                return TimeSpan.FromTicks(_totalTicksConsumed / _totalActivations);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Starts timing a creature's turn.
+    /// </summary>
+    public void StartTiming()
+    {
+        _stopwatch.Restart();
+    }
+
+    /// <summary>
+    /// Stops timing and records the CPU usage for this turn.
+    /// Returns the elapsed time and whether the quantum was exceeded.
+    /// </summary>
+    /// <param name="quantumMs">The allowed quantum in milliseconds.</param>
+    /// <returns>A tuple of (elapsed time, exceeded quantum).</returns>
+    public (TimeSpan elapsed, bool exceeded) StopTiming(int quantumMs = DefaultQuantumMs)
+    {
+        _stopwatch.Stop();
+        var elapsed = _stopwatch.Elapsed;
+        var elapsedTicks = _stopwatch.ElapsedTicks;
+
+        lock (_lock)
+        {
+            _lastTicksConsumed = elapsedTicks;
+            _totalTicksConsumed += elapsedTicks;
+            _totalActivations++;
+
+            var quantumTicks = (long)(quantumMs * Stopwatch.Frequency / 1000.0);
+            if (elapsedTicks > quantumTicks)
+            {
+                _overageTicks += elapsedTicks - quantumTicks;
+                _penaltyMultiplier = Math.Min(_penaltyMultiplier + 1, MaxPenaltyMultiplier);
+                return (elapsed, true);
+            }
+
+            // Decay penalty when within quantum
+            if (_penaltyMultiplier > 0)
+                _penaltyMultiplier--;
+        }
+
+        return (elapsed, false);
+    }
+
+    /// <summary>
+    /// Gets the effective quantum for this creature, accounting for penalties.
+    /// Penalized creatures get a reduced quantum.
+    /// </summary>
+    /// <param name="baseQuantumMs">The base quantum in milliseconds.</param>
+    /// <returns>The effective quantum after penalty adjustment.</returns>
+    public int GetEffectiveQuantumMs(int baseQuantumMs = DefaultQuantumMs)
+    {
+        lock (_lock)
+        {
+            if (_penaltyMultiplier == 0) return baseQuantumMs;
+            return Math.Max(1, baseQuantumMs / (_penaltyMultiplier + 1));
+        }
+    }
+
+    /// <summary>
+    /// Resets all tracking counters.
+    /// </summary>
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            _totalTicksConsumed = 0;
+            _totalActivations = 0;
+            _lastTicksConsumed = 0;
+            _penaltyMultiplier = 0;
+            _overageTicks = 0;
+        }
+    }
+}

--- a/src/Terrarium.Game/Hosting/OrganismSandbox.cs
+++ b/src/Terrarium.Game/Hosting/OrganismSandbox.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Microsoft.Extensions.Logging;
+
+namespace Terrarium.Game.Hosting;
+
+/// <summary>
+/// Isolates creature assemblies using AssemblyLoadContext.
+/// Each creature type gets its own collectible load context,
+/// enabling assembly unloading and memory reclamation.
+/// </summary>
+public sealed class OrganismSandbox : IDisposable
+{
+    private readonly ILogger<OrganismSandbox> _logger;
+    private readonly ConcurrentDictionary<string, CreatureLoadContext> _contexts = new();
+    private bool _disposed;
+
+    public OrganismSandbox(ILogger<OrganismSandbox> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Loads a creature assembly from raw bytes into an isolated AssemblyLoadContext.
+    /// Each creature type (keyed by assembly full name) gets its own context.
+    /// </summary>
+    /// <param name="assemblyBytes">The raw assembly bytes to load.</param>
+    /// <returns>The loaded assembly within its isolated context.</returns>
+    public Assembly LoadCreatureAssembly(byte[] assemblyBytes)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (assemblyBytes == null || assemblyBytes.Length == 0)
+            throw new ArgumentException("Assembly bytes cannot be null or empty.", nameof(assemblyBytes));
+
+        // Load into a new isolated context
+        var context = new CreatureLoadContext($"Creature_{Guid.NewGuid():N}");
+        Assembly assembly;
+        using (var loadStream = new MemoryStream(assemblyBytes))
+        {
+            assembly = context.LoadFromStream(loadStream);
+        }
+
+        var key = assembly.FullName ?? assembly.GetName().Name ?? context.Name!;
+
+        // Unload existing context for this assembly if present
+        if (_contexts.TryRemove(key, out var existingContext))
+        {
+            _logger.LogInformation("Unloading previous context for {Assembly}", key);
+            existingContext.Unload();
+        }
+
+        _contexts[key] = context;
+        _logger.LogInformation("Loaded creature assembly '{Name}' into isolated context", key);
+
+        return assembly;
+    }
+
+    /// <summary>
+    /// Unloads the context for a specific assembly, freeing all associated memory.
+    /// </summary>
+    /// <param name="assemblyFullName">The full name of the assembly to unload.</param>
+    /// <returns>True if the context was found and unloaded; false otherwise.</returns>
+    public bool UnloadCreatureAssembly(string assemblyFullName)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_contexts.TryRemove(assemblyFullName, out var context))
+        {
+            context.Unload();
+            _logger.LogInformation("Unloaded creature context: {Assembly}", assemblyFullName);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the names of all currently loaded creature assemblies.
+    /// </summary>
+    public IReadOnlyCollection<string> LoadedAssemblies => _contexts.Keys.ToArray();
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        foreach (var kvp in _contexts)
+        {
+            try { kvp.Value.Unload(); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error unloading context {Assembly}", kvp.Key);
+            }
+        }
+        _contexts.Clear();
+    }
+
+    /// <summary>
+    /// A collectible AssemblyLoadContext that isolates creature code
+    /// and can be unloaded to reclaim memory.
+    /// </summary>
+    private sealed class CreatureLoadContext : AssemblyLoadContext
+    {
+        public CreatureLoadContext(string name) : base(name, isCollectible: true) { }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            // Return null to fall back to the default context for shared framework assemblies.
+            // Creature assemblies should only reference OrganismBase and standard BCL types,
+            // which are already loaded in the default context.
+            return null;
+        }
+    }
+}

--- a/src/Terrarium.Game/Hosting/OrganismScheduler.cs
+++ b/src/Terrarium.Game/Hosting/OrganismScheduler.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using OrganismBase;
+
+namespace Terrarium.Game.Hosting;
+
+/// <summary>
+/// Fair round-robin scheduler for organism turn execution.
+/// Distributes CPU time across all organisms, enforcing time
+/// quanta and penalizing creatures that exceed their allocation.
+/// </summary>
+public sealed class OrganismScheduler : IOrganismScheduler, IDisposable
+{
+    /// <summary>
+    /// Number of ticks (Tick() calls) per game tick.
+    /// The game engine calls Tick() during phases 0-4.
+    /// </summary>
+    public const int TicksPerGameTick = 5;
+
+    private readonly ILogger<OrganismScheduler> _logger;
+    private readonly OrganismHost _host;
+    private readonly ConcurrentDictionary<string, OrganismEntry> _organisms = new();
+    private readonly List<string> _roundRobinOrder = new();
+    private readonly object _scheduleLock = new();
+
+    private int _tickIndex;
+    private bool _disposed;
+
+    public OrganismScheduler(ILogger<OrganismScheduler> logger, OrganismHost host)
+    {
+        _logger = logger;
+        _host = host;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<Organism> Organisms =>
+        _organisms.Values.Select(e => e.Organism).ToArray();
+
+    /// <inheritdoc />
+    public WorldState? CurrentState { get; set; }
+
+    /// <inheritdoc />
+    public Organism? Create(Type creatureType, string id)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (creatureType == null) throw new ArgumentNullException(nameof(creatureType));
+        if (string.IsNullOrEmpty(id)) throw new ArgumentException("ID cannot be null or empty.", nameof(id));
+
+        try
+        {
+            var organism = (Organism?)Activator.CreateInstance(creatureType);
+            if (organism == null)
+            {
+                _logger.LogError("Failed to create organism of type {Type}", creatureType.FullName);
+                return null;
+            }
+
+            var entry = new OrganismEntry(organism, new OrganismQuanta());
+            if (!_organisms.TryAdd(id, entry))
+            {
+                _logger.LogWarning("Organism with ID {ID} already exists", id);
+                return null;
+            }
+
+            lock (_scheduleLock)
+            {
+                _roundRobinOrder.Add(id);
+            }
+
+            _logger.LogDebug("Created organism {ID} of type {Type}", id, creatureType.Name);
+            return organism;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create organism of type {Type}", creatureType.FullName);
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Remove(string id)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_organisms.TryRemove(id, out _))
+        {
+            lock (_scheduleLock)
+            {
+                _roundRobinOrder.Remove(id);
+            }
+            _logger.LogDebug("Removed organism {ID}", id);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Tick()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        string[] currentBatch;
+        lock (_scheduleLock)
+        {
+            if (_roundRobinOrder.Count == 0) return;
+
+            // Divide organisms into TicksPerGameTick batches.
+            // Each Tick() call processes one batch.
+            var total = _roundRobinOrder.Count;
+            var batchSize = Math.Max(1, (total + TicksPerGameTick - 1) / TicksPerGameTick);
+            var start = _tickIndex * batchSize;
+
+            if (start >= total)
+            {
+                _tickIndex = (_tickIndex + 1) % TicksPerGameTick;
+                return;
+            }
+
+            var count = Math.Min(batchSize, total - start);
+            currentBatch = _roundRobinOrder.GetRange(start, count).ToArray();
+            _tickIndex = (_tickIndex + 1) % TicksPerGameTick;
+        }
+
+        foreach (var id in currentBatch)
+        {
+            if (!_organisms.TryGetValue(id, out var entry)) continue;
+
+            var quanta = entry.Quanta;
+            var effectiveQuantum = quanta.GetEffectiveQuantumMs();
+            var timeout = TimeSpan.FromMilliseconds(effectiveQuantum);
+
+            quanta.StartTiming();
+            var result = _host.ExecuteTurn(entry.Organism, timeout);
+            var (_, exceeded) = quanta.StopTiming(effectiveQuantum);
+
+            if (exceeded)
+            {
+                _logger.LogDebug("Organism {ID} exceeded quantum (penalty={Penalty})",
+                    id, quanta.PenaltyMultiplier);
+            }
+
+            if (!result.Completed && result.ErrorMessage != null)
+            {
+                _logger.LogWarning("Organism {ID}: {Error}", id, result.ErrorMessage);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public Organism? GetOrganism(string id)
+    {
+        _organisms.TryGetValue(id, out var entry);
+        return entry?.Organism;
+    }
+
+    /// <inheritdoc />
+    public OrganismQuanta? GetQuanta(string id)
+    {
+        _organisms.TryGetValue(id, out var entry);
+        return entry?.Quanta;
+    }
+
+    /// <inheritdoc />
+    public void Destroy()
+    {
+        Dispose();
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        lock (_scheduleLock)
+        {
+            _roundRobinOrder.Clear();
+        }
+        _organisms.Clear();
+        _logger.LogInformation("OrganismScheduler destroyed");
+    }
+
+    private sealed class OrganismEntry
+    {
+        public Organism Organism { get; }
+        public OrganismQuanta Quanta { get; }
+
+        public OrganismEntry(Organism organism, OrganismQuanta quanta)
+        {
+            Organism = organism;
+            Quanta = quanta;
+        }
+    }
+}


### PR DESCRIPTION
## Sprint 6: Security Sandboxing

Closes #43

### Architecture
- **OrganismSandbox**: AssemblyLoadContext per creature type, collectible for memory reclamation
- **OrganismHost**: Safe execution with CancellationToken timeout + CPU tracking
- **CreatureValidator**: Static IL analysis for forbidden patterns (P/Invoke, System.IO, System.Net, etc.)
- **OrganismQuanta**: Per-creature CPU time measurement with penalty system
- **OrganismScheduler**: Fair round-robin scheduling, 5 batches per game tick (phases 0-4)
- **IOrganismScheduler**: Interface for swappable scheduler implementations

### Decision Document
- \.ai-team/decisions/inbox/heisenberg-isolation-architecture.md\ — documents why AssemblyLoadContext over worker processes, security tradeoffs, and future considerations

### Build
- \dotnet build src/Terrarium.sln\ passes with 0 errors in Terrarium.Game (pre-existing errors in Terrarium.Server are unrelated)