### PR TITLE
SignalR Blazor client + gRPC stub

### DIFF
--- a/src/Terrarium.Server/Protos/terrarium.proto
+++ b/src/Terrarium.Server/Protos/terrarium.proto
@@ -1,0 +1,37 @@
+// Future: Multi-server gRPC communication for geo-distributed ecosystems
+
+syntax = "proto3";
+
+option csharp_namespace = "Terrarium.Server.Protos";
+
+package terrarium;
+
+// Service definition for server-to-server communication.
+service TerrariumService {
+  // Returns the current world state for an ecosystem.
+  rpc GetWorldState (WorldStateRequest) returns (WorldStateResponse);
+
+  // Exchanges peer information between servers for geo-distributed routing.
+  rpc ExchangePeers (PeerInfo) returns (PeerInfo);
+}
+
+message WorldStateRequest {
+  string ecosystem_id = 1;
+  int64 since_tick = 2;
+}
+
+message WorldStateResponse {
+  string ecosystem_id = 1;
+  int64 tick_number = 2;
+  int32 world_width = 3;
+  int32 world_height = 4;
+  int32 organism_count = 5;
+  string timestamp = 6;
+}
+
+message PeerInfo {
+  string peer_id = 1;
+  string ecosystem_id = 2;
+  string server_address = 3;
+  string region = 4;
+}

--- a/src/Terrarium.Web/Components/Pages/Home.razor
+++ b/src/Terrarium.Web/Components/Pages/Home.razor
@@ -1,6 +1,9 @@
 @page "/"
 @rendermode InteractiveServer
 @using Terrarium.Web.Models
+@using Terrarium.Web.Services
+@inject TerrariumHubConnection HubConnection
+@implements IDisposable
 
 <PageTitle>.NET Terrarium</PageTitle>
 
@@ -53,8 +56,51 @@
         _tickCount = 0;
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            HubConnection.OnWorldStateReceived += OnWorldStateReceived;
+            HubConnection.OnCreatureUpdate += OnCreatureUpdate;
+            HubConnection.OnPeerDiscovered += OnPeerDiscovered;
+
+            await HubConnection.ConnectAsync();
+            _isRunning = true;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task OnWorldStateReceived(Terrarium.Net.WorldStateUpdate update)
+    {
+        _tickCount = (int)update.TickNumber;
+        _messages.Add(new MessageLog.GameMessage(DateTime.Now,
+            $"World state received: tick {update.TickNumber}, {update.OrganismCount} organisms"));
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnCreatureUpdate(Terrarium.Net.EcosystemTick tick)
+    {
+        _tickCount = (int)tick.TickNumber;
+        _peerCount = tick.PeerCount;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnPeerDiscovered(Terrarium.Net.PeerAnnounce announce)
+    {
+        _messages.Add(new MessageLog.GameMessage(DateTime.Now,
+            $"Peer {announce.PeerId} {announce.Action}"));
+        await InvokeAsync(StateHasChanged);
+    }
+
     private void OnCreatureSelected(CreatureInfo creature)
     {
         _selectedCreature = creature;
+    }
+
+    public void Dispose()
+    {
+        HubConnection.OnWorldStateReceived -= OnWorldStateReceived;
+        HubConnection.OnCreatureUpdate -= OnCreatureUpdate;
+        HubConnection.OnPeerDiscovered -= OnPeerDiscovered;
     }
 }

--- a/src/Terrarium.Web/Program.cs
+++ b/src/Terrarium.Web/Program.cs
@@ -1,5 +1,6 @@
 using Terrarium.Configuration;
 using Terrarium.Web.Components;
+using Terrarium.Web.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,6 +16,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 builder.Services.AddSignalR();
+builder.Services.AddSingleton<TerrariumHubConnection>();
 
 var app = builder.Build();
 

--- a/src/Terrarium.Web/Services/TerrariumHubConnection.cs
+++ b/src/Terrarium.Web/Services/TerrariumHubConnection.cs
@@ -1,0 +1,110 @@
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.Logging;
+using Terrarium.Net;
+
+namespace Terrarium.Web.Services;
+
+/// <summary>
+/// Manages the SignalR connection from the Blazor client to the Terrarium server hub.
+/// </summary>
+public sealed class TerrariumHubConnection : IAsyncDisposable
+{
+    private readonly HubConnection _hub;
+    private readonly ILogger<TerrariumHubConnection> _logger;
+
+    /// <summary>Fires when a full world state snapshot arrives.</summary>
+    public event Func<WorldStateUpdate, Task>? OnWorldStateReceived;
+
+    /// <summary>Fires on each ecosystem tick with lightweight creature data.</summary>
+    public event Func<EcosystemTick, Task>? OnCreatureUpdate;
+
+    /// <summary>Fires when a peer joins or leaves the ecosystem.</summary>
+    public event Func<PeerAnnounce, Task>? OnPeerDiscovered;
+
+    public TerrariumHubConnection(IConfiguration configuration, ILogger<TerrariumHubConnection> logger)
+    {
+        _logger = logger;
+
+        var serverUrl = configuration["services:server:https:0"]
+                        ?? configuration["services:server:http:0"]
+                        ?? "https+http://server";
+
+        var hubUrl = $"{serverUrl}/terrarium-hub";
+
+        _hub = new HubConnectionBuilder()
+            .WithUrl(hubUrl)
+            .WithAutomaticReconnect()
+            .Build();
+
+        _hub.On<WorldStateUpdate>(nameof(ITerrariumClient.ReceiveWorldStateUpdate), async update =>
+        {
+            if (OnWorldStateReceived is not null)
+                await OnWorldStateReceived.Invoke(update);
+        });
+
+        _hub.On<EcosystemTick>(nameof(ITerrariumClient.ReceiveEcosystemTick), async tick =>
+        {
+            if (OnCreatureUpdate is not null)
+                await OnCreatureUpdate.Invoke(tick);
+        });
+
+        _hub.On<PeerAnnounce>(nameof(ITerrariumClient.ReceivePeerAnnounce), async announce =>
+        {
+            if (OnPeerDiscovered is not null)
+                await OnPeerDiscovered.Invoke(announce);
+        });
+    }
+
+    /// <summary>Establish the SignalR hub connection.</summary>
+    public async Task ConnectAsync()
+    {
+        try
+        {
+            await _hub.StartAsync();
+            _logger.LogInformation("Connected to Terrarium hub");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to connect to Terrarium hub");
+        }
+    }
+
+    /// <summary>Cleanly shut down the hub connection.</summary>
+    public async Task DisconnectAsync()
+    {
+        try
+        {
+            await _hub.StopAsync();
+            _logger.LogInformation("Disconnected from Terrarium hub");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error during hub disconnect");
+        }
+    }
+
+    /// <summary>Announce this client as a peer in the given ecosystem.</summary>
+    public async Task RegisterAsPeer(string ecosystemId = "default")
+    {
+        var announce = new PeerAnnounce
+        {
+            PeerId = _hub.ConnectionId ?? "unknown",
+            EcosystemId = ecosystemId,
+            Action = PeerAction.Join
+        };
+
+        await _hub.InvokeAsync(nameof(ITerrariumHub.AnnouncePeer), announce);
+        _logger.LogInformation("Registered as peer in ecosystem {EcosystemId}", ecosystemId);
+    }
+
+    /// <summary>Submit creature actions to the server (placeholder for future game loop).</summary>
+    public async Task SendActions(CreatureTeleport teleport)
+    {
+        await _hub.InvokeAsync(nameof(ITerrariumHub.TeleportCreature), teleport);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _hub.DisposeAsync();
+    }
+}

--- a/src/Terrarium.Web/Terrarium.Web.csproj
+++ b/src/Terrarium.Web/Terrarium.Web.csproj
@@ -1,7 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Terrarium.Configuration\Terrarium.Configuration.csproj" />
+    <ProjectReference Include="..\Terrarium.Net\Terrarium.Net.csproj" />
     <ProjectReference Include="..\Terrarium.ServiceDefaults\Terrarium.ServiceDefaults.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Sprint 7

Closes #51, #54

- TerrariumHubConnection service for Blazor
- SignalR client integration in Home page
- gRPC proto file for future server-to-server comms